### PR TITLE
remove munin reporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,11 +59,6 @@
       <version>14.0.1</version>
     </dependency>
     <dependency>
-      <groupId>com.spotify</groupId>
-      <artifactId>metrics-munin-reporter</artifactId>
-      <version>0.8.16</version>
-    </dependency>
-    <dependency>
       <groupId>com.yammer.metrics</groupId>
       <artifactId>metrics-core</artifactId>
       <version>2.2.0</version>
@@ -72,6 +67,11 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>2.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.5</version>
     </dependency>
 
     <dependency>
@@ -104,7 +104,6 @@
       <version>1.7.5</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
   <build>

--- a/src/main/java/com/spotify/dns/DnsSrvResolvers.java
+++ b/src/main/java/com/spotify/dns/DnsSrvResolvers.java
@@ -16,16 +16,14 @@
 
 package com.spotify.dns;
 
-import com.spotify.statistics.MuninGraphCategoryConfig;
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.MetricName;
+
 import org.xbill.DNS.Lookup;
 
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.primitives.Ints.checkedCast;
-import static com.spotify.statistics.Property.CounterProperty;
-import static com.spotify.statistics.Property.TimerProperty;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -41,23 +39,6 @@ public final class DnsSrvResolvers {
 
   public static DnsSrvResolverBuilder newBuilder() {
     return new DnsSrvResolverBuilder(false, false, false, SECONDS.toMillis(DEFAULT_DNS_TIMEOUT_SECONDS));
-  }
-
-  public static void configureMuninGraphs(MuninGraphCategoryConfig category) {
-    category.graph("DNS Lookups")
-        .muninName("dns_lookups")
-        .vlabel("r/s")
-        .dataSource(TIMER_NAME, "total", TimerProperty.COUNT)
-        .dataSource(TIMER_NAME, "5 min rate", TimerProperty.FIVE_MINUTE_RATE)
-        .dataSource(FAILURES_NAME, "failure", CounterProperty.COUNT)
-        .dataSource(EMPTY_RESULTS_NAME, "empty", CounterProperty.COUNT);
-
-    category.graph("DNS lookup durations")
-        .muninName("dns_lookup_durations")
-        .dataSource(TIMER_NAME, "50%", TimerProperty.MEAN)
-        .dataSource(TIMER_NAME, "95%", TimerProperty.PERCENTILE95)
-        .dataSource(TIMER_NAME, "99%", TimerProperty.PERCENTILE99)
-        .dataSource(TIMER_NAME, "stddev", TimerProperty.STD_DEV);
   }
 
   public static final class DnsSrvResolverBuilder {

--- a/src/test/java/com/spotify/dns/examples/BasicUsage.java
+++ b/src/test/java/com/spotify/dns/examples/BasicUsage.java
@@ -17,12 +17,10 @@
 package com.spotify.dns.examples;
 
 import com.google.common.net.HostAndPort;
-import com.spotify.dns.DnsSrvResolver;
+
 import com.spotify.dns.DnsException;
+import com.spotify.dns.DnsSrvResolver;
 import com.spotify.dns.DnsSrvResolvers;
-import com.spotify.statistics.MuninReporter;
-import com.spotify.statistics.MuninReporterConfig;
-import com.yammer.metrics.Metrics;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -38,13 +36,6 @@ public class BasicUsage {
         .metered(true)
         .dnsLookupTimeoutMillis(1000)
         .build();
-
-    MuninReporterConfig reporterConfig = new MuninReporterConfig();
-
-    DnsSrvResolvers.configureMuninGraphs(reporterConfig.category("dns"));
-
-    MuninReporter reporter = new MuninReporter(Metrics.defaultRegistry(), reporterConfig);
-    reporter.start();
 
     boolean quit = false;
     BufferedReader in = new BufferedReader(new InputStreamReader(System.in));


### PR DESCRIPTION
Metric reporters should be set up by the user of
this library, without the library mandating any
specific reporter.
