### PR TITLE
Add a ChangeNotifier useful for testing

### DIFF
--- a/src/main/java/com/spotify/dns/DirectChangeNotifier.java
+++ b/src/main/java/com/spotify/dns/DirectChangeNotifier.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2015 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.spotify.dns;
+
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+class DirectChangeNotifier<T> extends AbstractChangeNotifier<T>
+    implements ChangeNotifierFactory.RunnableChangeNotifier<T> {
+
+  private final Supplier<Set<T>> recordsSupplier;
+
+  private volatile Set<T> records = ImmutableSet.of();
+  private volatile boolean run = true;
+
+  public DirectChangeNotifier(Supplier<Set<T>> recordsSupplier) {
+    this.recordsSupplier = checkNotNull(recordsSupplier, "recordsSupplier");
+  }
+
+  @Override
+  protected void closeImplementation() {
+    run = false;
+  }
+
+  @Override
+  public Set<T> current() {
+    return records;
+  }
+
+  @Override
+  public void run() {
+    if (!run) {
+      return;
+    }
+
+    final Set<T> current = recordsSupplier.get();
+    if (!current.equals(records)) {
+      final ChangeNotification<T> changeNotification =
+          newChangeNotification(current, records);
+      records = current;
+
+      fireRecordsUpdated(changeNotification);
+    }
+  }
+}


### PR DESCRIPTION
This is good to have when testing

```java
AtomicReference<Set<String>> endpointsRef = new AtomicReference<Set<String>>(EMPTY);
RunnableChangeNotifier<String> changeNotifier = ChangeNotifiers.direct(endpointsRef);

// ...

endpointsRef.set(ImmutableSet.of("tcp://foo:4711"));
changeNotifier.run();
```