### PR TITLE
Add OSGi meta-data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <guava.version>19.0</guava.version>
+        <guava.version>12.0</guava.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.spotify</groupId>
     <artifactId>dns</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <version>3.0.3-SNAPSHOT</version>
     <name>Spotify DNS wrapper library</name>
     <description>A thin wrapper around dnsjava for some features related to SRV lookups.
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <guava.version>11.0.2</guava.version>
+        <guava.version>19.0</guava.version>
     </properties>
 
     <scm>
@@ -211,6 +211,35 @@
                         </configuration>
                         <goals>
                             <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.0.1</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Name>${project.name}</Bundle-Name>
+                        <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package>
+                            com.spotify.dns;-noimport:=true,
+                            com.spotify.dns.statistics;-noimport:=true
+                        </Export-Package>
+                        <Implementation-Title>${project.name}</Implementation-Title>
+                        <Implementation-Version>${project.version}</Implementation-Version>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <!--
+                      This execution makes sure that the manifest is available
+                      when the tests are executed
+                    -->
+                    <execution>
+                        <goals>
+                            <goal>manifest</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION


```
Spotify DNS wrapper library (58)
--------------------------------
Bnd-LastModified = 1450866748625
Build-Jdk = 1.8.0_66
Built-By = lburgazz
Created-By = Apache Maven Bundle Plugin
Implementation-Title = Spotify DNS wrapper library
Implementation-Version = 3.0.3-SNAPSHOT
Manifest-Version = 1.0
Tool = Bnd-3.0.0.201509101326

Bundle-Description = A thin wrapper around dnsjava for some features related to SRV lookups.
Bundle-License = http://www.apache.org/licenses/LICENSE-2.0.txt
Bundle-ManifestVersion = 2
Bundle-Name = Spotify DNS wrapper library
Bundle-SymbolicName = com.spotify.dns
Bundle-Version = 3.0.3.SNAPSHOT

Require-Capability = 
	osgi.ee;filter:=(&(osgi.ee=JavaSE)(version=1.6))

Export-Package = 
	com.spotify.dns;uses:="com.google.common.base,com.spotify.dns.statistics,javax.annotation,org.xbill.DNS";version=3.0.3,
	com.spotify.dns.statistics;version=3.0.3
Import-Package = 
	com.google.common.base,
	com.google.common.cache,
	com.google.common.collect,
	com.google.common.primitives,
	com.google.common.util.concurrent,
	javax.annotation,
	org.slf4j;version="[1.7,2)",
	org.xbill.DNS;version="[2.1,3)"
```