### PR TITLE
Fix change notification for empty DNS result.

### DIFF
--- a/src/main/java/com/spotify/dns/AggregatingChangeNotifier.java
+++ b/src/main/java/com/spotify/dns/AggregatingChangeNotifier.java
@@ -30,6 +30,7 @@ class AggregatingChangeNotifier<T> extends AbstractChangeNotifier<T> {
   private final List<ChangeNotifier<T>> changeNotifiers;
 
   private volatile Set<T> records = ImmutableSet.of();
+  private volatile boolean waitingForFirstEvent = true;
 
   /**
    * Create a new aggregating {@link ChangeNotifier}.
@@ -67,7 +68,8 @@ class AggregatingChangeNotifier<T> extends AbstractChangeNotifier<T> {
   private synchronized void checkChange() {
     Set<T> currentRecords = aggregateSet();
 
-    if (!currentRecords.equals(records)) {
+    if (waitingForFirstEvent || !currentRecords.equals(records)) {
+      waitingForFirstEvent = false;
       final ChangeNotification<T> changeNotification =
           newChangeNotification(currentRecords, records);
       records = currentRecords;

--- a/src/main/java/com/spotify/dns/DirectChangeNotifier.java
+++ b/src/main/java/com/spotify/dns/DirectChangeNotifier.java
@@ -29,6 +29,7 @@ class DirectChangeNotifier<T> extends AbstractChangeNotifier<T>
   private final Supplier<Set<T>> recordsSupplier;
 
   private volatile Set<T> records = ImmutableSet.of();
+  private volatile boolean waitingForFirstEvent = true;
   private volatile boolean run = true;
 
   public DirectChangeNotifier(Supplier<Set<T>> recordsSupplier) {
@@ -52,7 +53,8 @@ class DirectChangeNotifier<T> extends AbstractChangeNotifier<T>
     }
 
     final Set<T> current = recordsSupplier.get();
-    if (!current.equals(records)) {
+    if (waitingForFirstEvent || !current.equals(records)) {
+      waitingForFirstEvent = false;
       final ChangeNotification<T> changeNotification =
           newChangeNotification(current, records);
       records = current;

--- a/src/main/java/com/spotify/dns/ServiceResolvingChangeNotifier.java
+++ b/src/main/java/com/spotify/dns/ServiceResolvingChangeNotifier.java
@@ -101,11 +101,11 @@ class ServiceResolvingChangeNotifier<T> extends AbstractChangeNotifier<T>
         errorHandler.handle(fqdn, e);
       }
       log.error(e.getMessage(), e);
-      fireEmpty();
+      fireIfFirstError();
       return;
     } catch (Exception e) {
       log.error(e.getMessage(), e);
-      fireEmpty();
+      fireIfFirstError();
       return;
     }
 
@@ -119,7 +119,7 @@ class ServiceResolvingChangeNotifier<T> extends AbstractChangeNotifier<T>
       current = builder.build();
     } catch (Exception e) {
       log.error(e.getMessage(), e);
-      fireEmpty();
+      fireIfFirstError();
       return;
     }
 
@@ -133,7 +133,7 @@ class ServiceResolvingChangeNotifier<T> extends AbstractChangeNotifier<T>
     }
   }
 
-  private void fireEmpty() {
+  private void fireIfFirstError() {
     if (waitingForFirstEvent) {
       waitingForFirstEvent = false;
       fireRecordsUpdated(newChangeNotification(current(), current()));

--- a/src/main/java/com/spotify/dns/ServiceResolvingChangeNotifier.java
+++ b/src/main/java/com/spotify/dns/ServiceResolvingChangeNotifier.java
@@ -47,6 +47,7 @@ class ServiceResolvingChangeNotifier<T> extends AbstractChangeNotifier<T>
   private final ErrorHandler errorHandler;
 
   private volatile Set<T> records = ImmutableSet.of();
+  private volatile boolean waitingForFirstEvent = true;
 
   private volatile boolean run = true;
 
@@ -100,9 +101,11 @@ class ServiceResolvingChangeNotifier<T> extends AbstractChangeNotifier<T>
         errorHandler.handle(fqdn, e);
       }
       log.error(e.getMessage(), e);
+      fireEmpty();
       return;
     } catch (Exception e) {
       log.error(e.getMessage(), e);
+      fireEmpty();
       return;
     }
 
@@ -116,15 +119,24 @@ class ServiceResolvingChangeNotifier<T> extends AbstractChangeNotifier<T>
       current = builder.build();
     } catch (Exception e) {
       log.error(e.getMessage(), e);
+      fireEmpty();
       return;
     }
 
-    if (!current.equals(records)) {
+    if (waitingForFirstEvent || !current.equals(records)) {
+      waitingForFirstEvent = false;
       final ChangeNotification<T> changeNotification =
           newChangeNotification(current, records);
       records = current;
 
       fireRecordsUpdated(changeNotification);
+    }
+  }
+
+  private void fireEmpty() {
+    if (waitingForFirstEvent) {
+      waitingForFirstEvent = false;
+      fireRecordsUpdated(newChangeNotification(current(), current()));
     }
   }
 }

--- a/src/test/java/com/spotify/dns/AggregatingChangeNotifierTest.java
+++ b/src/test/java/com/spotify/dns/AggregatingChangeNotifierTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class AggregatingChangeNotifierTest {
   @Test
@@ -41,6 +42,7 @@ public class AggregatingChangeNotifierTest {
     childNotifier.set(ImmutableSet.<String>of());
 
     verify(listener, times(1)).onChange(any(ChangeNotifier.ChangeNotification.class));
+    verifyNoMoreInteractions(listener);
 
   }
 

--- a/src/test/java/com/spotify/dns/AggregatingChangeNotifierTest.java
+++ b/src/test/java/com/spotify/dns/AggregatingChangeNotifierTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2016 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spotify.dns;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class AggregatingChangeNotifierTest {
+  @Test
+  public void testEmptySet() throws Exception {
+    MyNotifier childNotifier = new MyNotifier();
+    AggregatingChangeNotifier<String> notifier = new AggregatingChangeNotifier<String>(ImmutableList.<ChangeNotifier<String>>of(childNotifier));
+
+    ChangeNotifier.Listener listener = mock(ChangeNotifier.Listener.class);
+    notifier.setListener(listener, false);
+
+    verify(listener, never()).onChange(any(ChangeNotifier.ChangeNotification.class));
+
+    childNotifier.set(ImmutableSet.<String>of());
+
+    verify(listener, times(1)).onChange(any(ChangeNotifier.ChangeNotification.class));
+
+  }
+
+  private static class MyNotifier extends AbstractChangeNotifier<String> {
+    private volatile Set<String> records = ImmutableSet.of();
+
+    @Override
+    protected void closeImplementation() {
+    }
+
+    @Override
+    public Set<String> current() {
+      return records;
+    }
+
+    public void set(Set<String> records) {
+      fireRecordsUpdated(newChangeNotification(records, current()));
+      this.records = records;
+    }
+  }
+}

--- a/src/test/java/com/spotify/dns/DnsSrvResolversIT.java
+++ b/src/test/java/com/spotify/dns/DnsSrvResolversIT.java
@@ -18,7 +18,6 @@ package com.spotify.dns;
 
 import com.spotify.dns.statistics.DnsReporter;
 import com.spotify.dns.statistics.DnsTimingContext;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -29,6 +28,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -62,7 +62,7 @@ public class DnsSrvResolversIT {
     resolver.resolve("_spotify-client._tcp.sto.spotify.net");
     verify(timingReporter).stop();
     verify(reporter, never()).reportFailure(isA(RuntimeException.class));
-    verify(reporter, never()).reportEmpty();
+    verify(reporter, times(1)).reportEmpty();
   }
 
   @Test

--- a/src/test/java/com/spotify/dns/ServiceResolvingChangeNotifierTest.java
+++ b/src/test/java/com/spotify/dns/ServiceResolvingChangeNotifierTest.java
@@ -205,6 +205,7 @@ public class ServiceResolvingChangeNotifierTest {
     sut.setListener(listener, false);
     sut.run();
 
+    verify(listener, times(1)).onChange(any(ChangeNotifier.ChangeNotification.class));
     verifyNoMoreInteractions(listener);
   }
 
@@ -224,6 +225,7 @@ public class ServiceResolvingChangeNotifierTest {
 
     verify(errorHandler).handle(FQDN, exception);
     verifyNoMoreInteractions(f);
+    verify(listener, times(1)).onChange(any(ChangeNotifier.ChangeNotification.class));
     verifyNoMoreInteractions(listener);
   }
 


### PR DESCRIPTION
Make sure an initial DNS change event is fired even if the result set
is empty. This is useful for differentiating "no result yet" from
"empty result".