### PR TITLE
Fix bug in previous patch for avoiding notifying for initial data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,21 @@
             <version>1.7.5</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.jayway.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>1.7.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Need explicit dependency on this to avoid conflict between awaitility and mockito -->
+        <dependency>
+            <groupId>org.objenesis</groupId>
+            <artifactId>objenesis</artifactId>
+            <version>2.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/src/main/java/com/spotify/dns/AbstractChangeNotifier.java
+++ b/src/main/java/com/spotify/dns/AbstractChangeNotifier.java
@@ -16,6 +16,7 @@
 
 package com.spotify.dns;
 
+import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,12 +118,22 @@ abstract class AbstractChangeNotifier<T> implements ChangeNotifier<T> {
 
     @Override
     public Set<T> current() {
-      return Collections.unmodifiableSet(current);
+      return unmodifiable(current);
+    }
+
+    private Set<T> unmodifiable(Set<T> set) {
+      if (ChangeNotifiers.isInitialEmptyData(set)) {
+        return set;
+      }
+      if (set instanceof ImmutableSet) {
+        return set;
+      }
+      return Collections.unmodifiableSet(set);
     }
 
     @Override
     public Set<T> previous() {
-      return Collections.unmodifiableSet(previous);
+      return unmodifiable(previous);
     }
   }
 }

--- a/src/main/java/com/spotify/dns/ChangeNotifiers.java
+++ b/src/main/java/com/spotify/dns/ChangeNotifiers.java
@@ -20,6 +20,8 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.Sets;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -28,7 +30,35 @@ import static com.spotify.dns.ChangeNotifierFactory.RunnableChangeNotifier;
 
 public final class ChangeNotifiers {
 
+  /**
+   * Ensure that we get a unique empty set that you can't create any other way
+   * (i.e. ImmutableSet.of() always returns the same instance).
+   *
+   * This is needed to distinguishing the initial state of change notifiers from
+   * when they have gotten proper data.
+   */
+  private static final Set INITIAL_EMPTY_DATA = Collections.unmodifiableSet(new HashSet());
+
   private ChangeNotifiers() {
+  }
+
+  /**
+   * Use this to determine if the data you get back from a notifier is the initial result of the result of a proper
+   * DNS lookup. This is useful for distinguishing a proper but empty DNS result from the case
+   * where a lookup has not completed yet.
+   * @param set
+   * @return true if the input is an initially empty set.
+   */
+  public static <T> boolean isInitialEmptyData(Set<T> set) {
+    return set == INITIAL_EMPTY_DATA;
+  }
+
+  static <T> Set<T> initialEmptyDataInstance() {
+    return INITIAL_EMPTY_DATA;
+  }
+
+  static <T> boolean isNoLongerInitial(Set<T> current, Set<T> previous) {
+    return isInitialEmptyData(previous) && !isInitialEmptyData(current);
   }
 
   /**

--- a/src/main/java/com/spotify/dns/DirectChangeNotifier.java
+++ b/src/main/java/com/spotify/dns/DirectChangeNotifier.java
@@ -17,7 +17,6 @@
 package com.spotify.dns;
 
 import com.google.common.base.Supplier;
-import com.google.common.collect.ImmutableSet;
 
 import java.util.Set;
 
@@ -28,8 +27,7 @@ class DirectChangeNotifier<T> extends AbstractChangeNotifier<T>
 
   private final Supplier<Set<T>> recordsSupplier;
 
-  private volatile Set<T> records = ImmutableSet.of();
-  private volatile boolean waitingForFirstEvent = true;
+  private volatile Set<T> records = ChangeNotifiers.initialEmptyDataInstance();
   private volatile boolean run = true;
 
   public DirectChangeNotifier(Supplier<Set<T>> recordsSupplier) {
@@ -53,8 +51,7 @@ class DirectChangeNotifier<T> extends AbstractChangeNotifier<T>
     }
 
     final Set<T> current = recordsSupplier.get();
-    if (waitingForFirstEvent || !current.equals(records)) {
-      waitingForFirstEvent = false;
+    if (ChangeNotifiers.isNoLongerInitial(current, records) || !current.equals(records)) {
       final ChangeNotification<T> changeNotification =
           newChangeNotification(current, records);
       records = current;
@@ -62,4 +59,5 @@ class DirectChangeNotifier<T> extends AbstractChangeNotifier<T>
       fireRecordsUpdated(changeNotification);
     }
   }
+
 }

--- a/src/test/java/com/spotify/dns/AggregatingChangeNotifierTest.java
+++ b/src/test/java/com/spotify/dns/AggregatingChangeNotifierTest.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -40,14 +39,12 @@ public class AggregatingChangeNotifierTest {
     verify(listener, never()).onChange(any(ChangeNotifier.ChangeNotification.class));
 
     childNotifier.set(ImmutableSet.<String>of());
-
-    verify(listener, times(1)).onChange(any(ChangeNotifier.ChangeNotification.class));
     verifyNoMoreInteractions(listener);
 
   }
 
   private static class MyNotifier extends AbstractChangeNotifier<String> {
-    private volatile Set<String> records = ImmutableSet.of();
+    private volatile Set<String> records = ChangeNotifiers.initialEmptyDataInstance();
 
     @Override
     protected void closeImplementation() {

--- a/src/test/java/com/spotify/dns/RetainingDnsSrvResolverTest.java
+++ b/src/test/java/com/spotify/dns/RetainingDnsSrvResolverTest.java
@@ -16,7 +16,6 @@
 
 package com.spotify.dns;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;


### PR DESCRIPTION
Now we will instead return a specially constructed empty set that
can be used to distinguish empty result from missing result.

There is a new method in ChangeNotifers that consumers can use to
detect this.

I apologize for the hacky code, if the major version is ever
bumped this should be revert so that the API can return an
Optional<Set<T>> instead, or avoid firing in ChangeNotifier.setListener(listener, true)
if no change has ever happened