### PR TITLE
pom: Upgrade to dnsjava 2.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>dnsjava</groupId>
             <artifactId>dnsjava</artifactId>
-            <version>2.1.7</version>
+            <version>2.1.8</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
A new version of dnsjava was release in January 2017 (the previous release is from 2015). It doesn't really affect us in any way that I can see but it seems nice to keep up with upstream. The [changelog](https://sourceforge.net/p/dnsjava/code/HEAD/tree/tags/dnsjava-2.1.8/Changelog):

> 1/3/2017:
> 	- 2.1.8 released
>
> 8/13/2016:
> 	- Add a Message constructor taking a ByteBuffer, and convert the DNSInput class to use a ByteBuffer internally. (patch from Marrache Mickael <mickoo95@users.sf.net>)
> 	- Add support for the OPENPGPKEY record. (patch from Valentin Hauner <vh@hnr.name>)
> 	- Add support for the SMIMEA record.
>
> 11/25/2015:
> 	- Add support for the CAA record.
>
> 8/21/2015:
> 	- Convert the TSIG code from using a custom HMAC implementation to the one in javax.crypto.Mac. (patch from Nick Sayer <nsayer@silverspringnet.com>)
>
> 4/21/2015:
> 	- Update the URI record implementation to match the latest spec. (patch from Anthony Kirby <anthonykirby@users.sf.net>)
>
> 2/15/2015
> 	- 2.1.7 released