### PR TITLE
Do not log error if error handler is set

### DIFF
--- a/src/main/java/com/spotify/dns/ServiceResolvingChangeNotifier.java
+++ b/src/main/java/com/spotify/dns/ServiceResolvingChangeNotifier.java
@@ -97,8 +97,10 @@ class ServiceResolvingChangeNotifier<T> extends AbstractChangeNotifier<T>
     } catch (DnsException e) {
       if (errorHandler != null) {
         errorHandler.handle(fqdn, e);
+        log.warn(e.getMessage(), e);
+      } else {
+        log.error(e.getMessage(), e);
       }
-      log.error(e.getMessage(), e);
       fireIfFirstError();
       return;
     } catch (Exception e) {


### PR DESCRIPTION
The users of this class can choose how they want to handle exceptions by
providing an error handler. Forcing the exception to be logged as error 
doesn't play nicely with certain use cases. Specifically, services like
sentry send reports for all errors. With current way of logging it's
impossible to disable these reports for DnsException without adding
very specific logging configurations.