### PR TITLE
Allow users to specify DNS servers to use

### DIFF
--- a/src/main/java/com/spotify/dns/SimpleLookupFactory.java
+++ b/src/main/java/com/spotify/dns/SimpleLookupFactory.java
@@ -18,6 +18,7 @@ package com.spotify.dns;
 
 import org.xbill.DNS.DClass;
 import org.xbill.DNS.Lookup;
+import org.xbill.DNS.Resolver;
 import org.xbill.DNS.TextParseException;
 import org.xbill.DNS.Type;
 
@@ -25,10 +26,25 @@ import org.xbill.DNS.Type;
  * A LookupFactory that always returns new instances.
  */
 public class SimpleLookupFactory implements LookupFactory {
+
+  private final Resolver resolver;
+
+  public SimpleLookupFactory() {
+    this(null);
+  }
+
+  public SimpleLookupFactory(Resolver resolver) {
+    this.resolver = resolver;
+  }
+
   @Override
   public Lookup forName(String fqdn) {
     try {
-      return new Lookup(fqdn, Type.SRV, DClass.IN);
+      final Lookup lookup = new Lookup(fqdn, Type.SRV, DClass.IN);
+      if (resolver != null) {
+        lookup.setResolver(resolver);
+      }
+      return lookup;
     } catch (TextParseException e) {
       throw new DnsException("unable to create lookup for name: " + fqdn, e);
     }

--- a/src/test/java/com/spotify/dns/DnsSrvResolversIT.java
+++ b/src/test/java/com/spotify/dns/DnsSrvResolversIT.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Lists;
 import com.jayway.awaitility.Awaitility;
 import com.spotify.dns.statistics.DnsReporter;
 import com.spotify.dns.statistics.DnsTimingContext;
+import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -29,6 +30,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import org.xbill.DNS.ExtendedResolver;
+import org.xbill.DNS.Lookup;
+import org.xbill.DNS.SimpleResolver;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
@@ -114,6 +118,16 @@ public class DnsSrvResolversIT {
   }
 
   @Test
+  public void shouldReturnResultsUsingSpecifiedServers() throws Exception {
+    final String server = new SimpleResolver().getAddress().getHostName();
+    final DnsSrvResolver resolver = DnsSrvResolvers
+        .newBuilder()
+        .servers(ImmutableList.of(server))
+        .build();
+    assertThat(resolver.resolve("_spotify-client._tcp.spotify.com").isEmpty(), is(false));
+  }
+
+  @Test
   public void shouldSucceedCreatingRetainingDnsResolver() throws Exception {
     try {
       resolver = DnsSrvResolvers.newBuilder().retainingDataOnFailures(true).build();
@@ -125,7 +139,6 @@ public class DnsSrvResolversIT {
       assertTrue("Illegal argument exception should not be thrown", false);
     }
   }
-
   // TODO: it would be nice to be able to also test things like intermittent DNS failures, etc.,
   // but that takes a lot of work setting up a DNS infrastructure that can be made to fail in a
   // controlled way, so I'm skipping that.


### PR DESCRIPTION
This PR modifies DnsSrvResolver to that each instance can be configured to use
specific DNS servers. This PR also makes it so that timeouts are configured per
instance, instead of globally.