### PR TITLE
Automatic-Module-Name added to the manifest.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,17 @@
                 </configuration>
             </plugin>
             <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.spotify.dns</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>1.2</version>


### PR DESCRIPTION
As described by http://branchandbound.net/blog/java/2017/12/automatic-module-name/ , adding `Automatic-Module-Name` allows us to move to Java 11 without worrying that the jar file name will change.