### PR TITLE
Add module declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,11 +55,6 @@
             <version>${guava.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <version>2.0.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.5</version>
@@ -289,7 +284,7 @@
             <plugin>
                 <groupId>com.github.siom79.japicmp</groupId>
                 <artifactId>japicmp-maven-plugin</artifactId>
-                <version>0.6.1</version>
+                <version>0.14.3</version>
                 <configuration>
                     <oldVersion>
                         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.spotify</groupId>
     <artifactId>dns</artifactId>
     <packaging>bundle</packaging>
-    <version>3.1.6-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <name>Spotify DNS wrapper library</name>
     <description>A thin wrapper around dnsjava for some features related to SRV lookups.
     </description>
@@ -12,7 +12,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <guava.version>12.0</guava.version>
+        <guava.version>28.2-jre</guava.version>
     </properties>
 
     <scm>
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>dnsjava</groupId>
             <artifactId>dnsjava</artifactId>
-            <version>2.1.8</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -57,12 +57,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.5</version>
+            <version>1.7.30</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.5</version>
+            <version>1.7.30</version>
             <scope>test</scope>
         </dependency>
 
@@ -233,6 +233,14 @@
                     <release>9</release>
                     <source>9</source>
                     <target>9</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <!-- Open up module for reflective access from junit/mockito -->
+                    <argLine>--add-opens com.spotify.dns/com.spotify.dns=ALL-UNNAMED</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -228,10 +228,11 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <release>9</release>
+                    <source>9</source>
+                    <target>9</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -255,7 +256,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>4.2.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>

--- a/src/main/java/com/spotify/dns/AbstractChangeNotifier.java
+++ b/src/main/java/com/spotify/dns/AbstractChangeNotifier.java
@@ -16,6 +16,8 @@
 
 package com.spotify.dns;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,8 +28,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 /**
  * A helper for implementing the {@link ChangeNotifier} interface.
  */
@@ -35,7 +35,7 @@ abstract class AbstractChangeNotifier<T> implements ChangeNotifier<T> {
 
   private static final Logger log = LoggerFactory.getLogger(AbstractChangeNotifier.class);
 
-  private final AtomicReference<Listener<T>> listenerRef = new AtomicReference<Listener<T>>();
+  private final AtomicReference<Listener<T>> listenerRef = new AtomicReference<>();
 
   private final AtomicBoolean listenerNotified = new AtomicBoolean(false);
 
@@ -43,16 +43,16 @@ abstract class AbstractChangeNotifier<T> implements ChangeNotifier<T> {
 
   @Override
   public void setListener(final Listener<T> listener, final boolean fire) {
-    checkNotNull(listener, "listener");
+    requireNonNull(listener, "listener");
 
     lock.lock();
     try {
-          if (!listenerRef.compareAndSet(null, listener)) {
+      if (!listenerRef.compareAndSet(null, listener)) {
         throw new IllegalStateException("Listener already set!");
       }
 
       if (fire) {
-        notifyListener(newChangeNotification(current(), Collections.<T>emptySet()), true);
+        notifyListener(newChangeNotification(current(), Set.of()), true);
       }
     } finally {
       lock.unlock();
@@ -81,7 +81,7 @@ abstract class AbstractChangeNotifier<T> implements ChangeNotifier<T> {
   private void notifyListener(ChangeNotification<T> changeNotification, boolean newListener) {
     lock.lock();
     try {
-      checkNotNull(changeNotification, "changeNotification");
+      requireNonNull(changeNotification, "changeNotification");
 
       final Listener<T> listener = listenerRef.get();
       if (listener != null) {
@@ -100,10 +100,10 @@ abstract class AbstractChangeNotifier<T> implements ChangeNotifier<T> {
   }
 
   protected final ChangeNotification<T> newChangeNotification(Set<T> current, Set<T> previous) {
-    checkNotNull(current, "current");
-    checkNotNull(previous, "previous");
+    requireNonNull(current, "current");
+    requireNonNull(previous, "previous");
 
-    return new ChangeNotificationImpl<T>(current, previous);
+    return new ChangeNotificationImpl<>(current, previous);
   }
 
   private static class ChangeNotificationImpl<T> implements ChangeNotification<T> {

--- a/src/main/java/com/spotify/dns/AggregatingChangeNotifier.java
+++ b/src/main/java/com/spotify/dns/AggregatingChangeNotifier.java
@@ -29,7 +29,7 @@ class AggregatingChangeNotifier<T> extends AbstractChangeNotifier<T> {
 
   private final List<ChangeNotifier<T>> changeNotifiers;
 
-  private volatile Set<T> records = ChangeNotifiers.initialEmptyDataInstance();
+  private volatile Set<T> records;
 
   /**
    * Create a new aggregating {@link ChangeNotifier}.
@@ -41,12 +41,7 @@ class AggregatingChangeNotifier<T> extends AbstractChangeNotifier<T> {
 
     // Set up forwarding of listeners
     for (final ChangeNotifier<T> changeNotifier : this.changeNotifiers) {
-      changeNotifier.setListener(new Listener<T>() {
-         @Override
-         public void onChange(final ChangeNotification<T> ignored) {
-           checkChange();
-         }
-       }, false);
+      changeNotifier.setListener(ignored -> checkChange(), false);
     }
 
     records = aggregateSet();

--- a/src/main/java/com/spotify/dns/ChangeNotifier.java
+++ b/src/main/java/com/spotify/dns/ChangeNotifier.java
@@ -59,6 +59,7 @@ public interface ChangeNotifier<T> {
   /**
    * A listener which will be called when the set of records change
    */
+  @FunctionalInterface
   interface Listener<T> {
 
     /**

--- a/src/main/java/com/spotify/dns/ChangeNotifiers.java
+++ b/src/main/java/com/spotify/dns/ChangeNotifiers.java
@@ -119,7 +119,7 @@ public final class ChangeNotifiers {
   /**
    * @deprecated Use {@link #direct(java.util.function.Supplier)}
    */
-  @Deprecated(since = "3.1.6")
+  @Deprecated(since = "3.2.0")
   public static <T> RunnableChangeNotifier<T> direct(com.google.common.base.Supplier<Set<T>> recordsSupplier) {
     return new DirectChangeNotifier<>(recordsSupplier);
   }

--- a/src/main/java/com/spotify/dns/DirectChangeNotifier.java
+++ b/src/main/java/com/spotify/dns/DirectChangeNotifier.java
@@ -16,11 +16,10 @@
 
 package com.spotify.dns;
 
-import com.google.common.base.Supplier;
+import static java.util.Objects.requireNonNull;
 
 import java.util.Set;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.function.Supplier;
 
 class DirectChangeNotifier<T> extends AbstractChangeNotifier<T>
     implements ChangeNotifierFactory.RunnableChangeNotifier<T> {
@@ -31,7 +30,7 @@ class DirectChangeNotifier<T> extends AbstractChangeNotifier<T>
   private volatile boolean run = true;
 
   public DirectChangeNotifier(Supplier<Set<T>> recordsSupplier) {
-    this.recordsSupplier = checkNotNull(recordsSupplier, "recordsSupplier");
+    this.recordsSupplier = requireNonNull(recordsSupplier, "recordsSupplier");
   }
 
   @Override

--- a/src/main/java/com/spotify/dns/DnsException.java
+++ b/src/main/java/com/spotify/dns/DnsException.java
@@ -16,8 +16,6 @@
 
 package com.spotify.dns;
 
-import javax.annotation.Nullable;
-
 /**
  * RuntimeException thrown by the Spotify DNS library.
  */
@@ -25,15 +23,15 @@ public class DnsException extends RuntimeException {
 	public DnsException() {
 	}
 
-	public DnsException(@Nullable String message) {
+	public DnsException(String message) {
 		super(message);
 	}
 
-	public DnsException(@Nullable String message, @Nullable Throwable cause) {
+	public DnsException(String message, Throwable cause) {
 		super(message, cause);
 	}
 
-	public DnsException(@Nullable Throwable cause) {
+	public DnsException(Throwable cause) {
 		super(cause);
 	}
 }

--- a/src/main/java/com/spotify/dns/DnsSrvResolvers.java
+++ b/src/main/java/com/spotify/dns/DnsSrvResolvers.java
@@ -16,7 +16,7 @@
 
 package com.spotify.dns;
 
-import static com.google.common.primitives.Ints.checkedCast;
+import static java.lang.Math.toIntExact;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -86,8 +86,8 @@ public final class DnsSrvResolvers {
       }
 
       // Configure the Resolver to use our timeouts.
-      int timeoutSecs = checkedCast(MILLISECONDS.toSeconds(dnsLookupTimeoutMillis));
-      int millisRemainder = checkedCast(dnsLookupTimeoutMillis - SECONDS.toMillis(timeoutSecs));
+      int timeoutSecs = toIntExact(MILLISECONDS.toSeconds(dnsLookupTimeoutMillis));
+      int millisRemainder = toIntExact(dnsLookupTimeoutMillis - SECONDS.toMillis(timeoutSecs));
       resolver.setTimeout(timeoutSecs, millisRemainder);
 
       LookupFactory lookupFactory = new SimpleLookupFactory(resolver);

--- a/src/main/java/com/spotify/dns/DnsSrvResolvers.java
+++ b/src/main/java/com/spotify/dns/DnsSrvResolvers.java
@@ -16,13 +16,12 @@
 
 package com.spotify.dns;
 
-import static java.lang.Math.toIntExact;
 import static java.util.concurrent.TimeUnit.HOURS;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.spotify.dns.statistics.DnsReporter;
 import java.net.UnknownHostException;
+import java.time.Duration;
 import java.util.List;
 import org.xbill.DNS.ExtendedResolver;
 import org.xbill.DNS.Resolver;
@@ -86,9 +85,8 @@ public final class DnsSrvResolvers {
       }
 
       // Configure the Resolver to use our timeouts.
-      int timeoutSecs = toIntExact(MILLISECONDS.toSeconds(dnsLookupTimeoutMillis));
-      int millisRemainder = toIntExact(dnsLookupTimeoutMillis - SECONDS.toMillis(timeoutSecs));
-      resolver.setTimeout(timeoutSecs, millisRemainder);
+      final Duration timeoutDuration = Duration.ofMillis(dnsLookupTimeoutMillis);
+      resolver.setTimeout(timeoutDuration);
 
       LookupFactory lookupFactory = new SimpleLookupFactory(resolver);
 

--- a/src/main/java/com/spotify/dns/DnsSrvWatcherFactory.java
+++ b/src/main/java/com/spotify/dns/DnsSrvWatcherFactory.java
@@ -25,6 +25,7 @@ package com.spotify.dns;
  *
  * @param <T> The record type
  */
+@FunctionalInterface
 public interface DnsSrvWatcherFactory<T> {
 
   /**

--- a/src/main/java/com/spotify/dns/DnsSrvWatchers.java
+++ b/src/main/java/com/spotify/dns/DnsSrvWatchers.java
@@ -16,18 +16,17 @@
 
 package com.spotify.dns;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
@@ -46,9 +45,9 @@ public final class DnsSrvWatchers {
    * @return a builder for further configuring the watcher
    */
   public static DnsSrvWatcherBuilder<LookupResult> newBuilder(DnsSrvResolver resolver) {
-    checkNotNull(resolver, "resolver");
+    requireNonNull(resolver, "resolver");
 
-    return new DnsSrvWatcherBuilder<LookupResult>(resolver, Functions.<LookupResult>identity());
+    return new DnsSrvWatcherBuilder<>(resolver, Function.identity());
   }
 
   /**
@@ -69,10 +68,20 @@ public final class DnsSrvWatchers {
       DnsSrvResolver resolver,
       Function<LookupResult, T> resultTransformer) {
 
-    checkNotNull(resolver, "resolver");
-    checkNotNull(resultTransformer, "resultTransformer");
+    requireNonNull(resolver, "resolver");
+    requireNonNull(resultTransformer, "resultTransformer");
 
-    return new DnsSrvWatcherBuilder<T>(resolver, resultTransformer);
+    return new DnsSrvWatcherBuilder<>(resolver, resultTransformer);
+  }
+
+  /**
+   * @deprecated Use {@link #newBuilder(DnsSrvResolver, java.util.function.Function)}
+   */
+  @Deprecated(since = "3.1.6")
+  public static <T> DnsSrvWatcherBuilder<T> newBuilder(
+      DnsSrvResolver resolver,
+      com.google.common.base.Function<LookupResult, T> resultTransformer) {
+    return newBuilder(resolver, resultTransformer);
   }
 
   public static final class DnsSrvWatcherBuilder<T> {
@@ -118,15 +127,6 @@ public final class DnsSrvWatchers {
     public DnsSrvWatcher<T> build() {
       checkState(polling ^ dnsSrvWatcherFactory != null, "specify either polling or custom trigger");
 
-      final ChangeNotifierFactory<T> changeNotifierFactory =
-          new ChangeNotifierFactory<T>() {
-            @Override
-            public RunnableChangeNotifier<T> create(String fqdn) {
-              return new ServiceResolvingChangeNotifier<T>(resolver, fqdn, resultTransformer,
-                                                           errorHandler);
-            }
-          };
-
       DnsSrvWatcherFactory<T> watcherFactory;
       if (polling) {
         final ScheduledExecutorService executor =
@@ -137,23 +137,22 @@ public final class DnsSrvWatchers {
                     1, new ThreadFactoryBuilder().setNameFormat("dns-lookup-%d").build()),
                 0, SECONDS);
 
-        watcherFactory = new DnsSrvWatcherFactory<T>() {
-          @Override
-          public DnsSrvWatcher<T> create(ChangeNotifierFactory<T> changeNotifierFactory) {
-            return new PollingDnsSrvWatcher<T>(changeNotifierFactory, executor, pollingInterval,
-                                               pollingIntervalUnit);
-          }
-        };
+        watcherFactory =
+            cnf -> new PollingDnsSrvWatcher<>(cnf, executor, pollingInterval, pollingIntervalUnit);
       } else {
-        watcherFactory = checkNotNull(dnsSrvWatcherFactory);
+        watcherFactory = requireNonNull(dnsSrvWatcherFactory, "dnsSrvWatcherFactory");
       }
+
+      final ChangeNotifierFactory<T> changeNotifierFactory =
+          fqdn -> new ServiceResolvingChangeNotifier<>(
+              resolver, fqdn, resultTransformer, errorHandler);
 
       return watcherFactory.create(changeNotifierFactory);
     }
 
     public DnsSrvWatcherBuilder<T> polling(long pollingInterval, TimeUnit pollingIntervalUnit) {
       checkArgument(pollingInterval > 0);
-      checkNotNull(pollingIntervalUnit, "pollingIntervalUnit");
+      requireNonNull(pollingIntervalUnit, "pollingIntervalUnit");
 
       return new DnsSrvWatcherBuilder<T>(resolver, resultTransformer, true, pollingInterval,
                                          pollingIntervalUnit, errorHandler, dnsSrvWatcherFactory,
@@ -167,7 +166,7 @@ public final class DnsSrvWatchers {
     }
 
     public DnsSrvWatcherBuilder<T> customTrigger(DnsSrvWatcherFactory<T> watcherFactory) {
-      checkNotNull(watcherFactory, "watcherFactory");
+      requireNonNull(watcherFactory, "watcherFactory");
 
       return new DnsSrvWatcherBuilder<T>(resolver, resultTransformer, true, pollingInterval,
                                          pollingIntervalUnit, errorHandler, watcherFactory,
@@ -175,7 +174,7 @@ public final class DnsSrvWatchers {
     }
 
     public DnsSrvWatcherBuilder<T> withErrorHandler(ErrorHandler errorHandler) {
-      checkNotNull(errorHandler, "errorHandler");
+      requireNonNull(errorHandler, "errorHandler");
 
       return new DnsSrvWatcherBuilder<T>(resolver, resultTransformer, true, pollingInterval,
                                          pollingIntervalUnit, errorHandler, dnsSrvWatcherFactory,

--- a/src/main/java/com/spotify/dns/DnsSrvWatchers.java
+++ b/src/main/java/com/spotify/dns/DnsSrvWatchers.java
@@ -77,7 +77,7 @@ public final class DnsSrvWatchers {
   /**
    * @deprecated Use {@link #newBuilder(DnsSrvResolver, java.util.function.Function)}
    */
-  @Deprecated(since = "3.1.6")
+  @Deprecated(since = "3.2.0")
   public static <T> DnsSrvWatcherBuilder<T> newBuilder(
       DnsSrvResolver resolver,
       com.google.common.base.Function<LookupResult, T> resultTransformer) {

--- a/src/main/java/com/spotify/dns/LookupResult.java
+++ b/src/main/java/com/spotify/dns/LookupResult.java
@@ -1,6 +1,6 @@
 package com.spotify.dns;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Immutable data object with the relevant parts of an SRV record.
@@ -15,7 +15,7 @@ public class LookupResult {
 
   private LookupResult(final String host, final int port, final int priority, final int weight,
                        final long ttl) {
-    this.host = checkNotNull(host, "host");
+    this.host = requireNonNull(host, "host");
     this.port = port;
     this.priority = priority;
     this.weight = weight;

--- a/src/main/java/com/spotify/dns/MeteredDnsSrvResolver.java
+++ b/src/main/java/com/spotify/dns/MeteredDnsSrvResolver.java
@@ -16,12 +16,12 @@
 
 package com.spotify.dns;
 
+import static java.util.Objects.requireNonNull;
+
 import com.spotify.dns.statistics.DnsReporter;
 import com.spotify.dns.statistics.DnsTimingContext;
 
 import java.util.List;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Tracks metrics for DnsSrvResolver calls.
@@ -31,8 +31,8 @@ class MeteredDnsSrvResolver implements DnsSrvResolver {
   private final DnsReporter reporter;
 
   MeteredDnsSrvResolver(DnsSrvResolver delegate, DnsReporter reporter) {
-    this.delegate = checkNotNull(delegate, "delegate");
-    this.reporter = checkNotNull(reporter, "reporter");
+    this.delegate = requireNonNull(delegate, "delegate");
+    this.reporter = requireNonNull(reporter, "reporter");
   }
 
   @Override

--- a/src/main/java/com/spotify/dns/PollingDnsSrvWatcher.java
+++ b/src/main/java/com/spotify/dns/PollingDnsSrvWatcher.java
@@ -21,8 +21,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.spotify.dns.ChangeNotifierFactory.RunnableChangeNotifier;
+import static java.util.Objects.requireNonNull;
 
 class PollingDnsSrvWatcher<T> implements DnsSrvWatcher<T> {
 
@@ -37,10 +37,10 @@ class PollingDnsSrvWatcher<T> implements DnsSrvWatcher<T> {
                        ScheduledExecutorService executor,
                        long pollingInterval,
                        TimeUnit pollingIntervalUnit) {
-    this.changeNotifierFactory = checkNotNull(changeNotifierFactory, "changeNotifierFactory");
-    this.executor = checkNotNull(executor, "executor");
+    this.changeNotifierFactory = requireNonNull(changeNotifierFactory, "changeNotifierFactory");
+    this.executor = requireNonNull(executor, "executor");
     this.pollingInterval = pollingInterval;
-    this.pollingIntervalUnit = checkNotNull(pollingIntervalUnit, "pollingIntervalUnit");
+    this.pollingIntervalUnit = requireNonNull(pollingIntervalUnit, "pollingIntervalUnit");
   }
 
   @Override

--- a/src/main/java/com/spotify/dns/RetainingDnsSrvResolver.java
+++ b/src/main/java/com/spotify/dns/RetainingDnsSrvResolver.java
@@ -16,6 +16,8 @@
 
 package com.spotify.dns;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.cache.Cache;
@@ -36,9 +38,9 @@ class RetainingDnsSrvResolver implements DnsSrvResolver {
 
   RetainingDnsSrvResolver(DnsSrvResolver delegate, long retentionTimeMillis) {
     Preconditions.checkArgument(retentionTimeMillis > 0L,
-                                "retention time must be positive, was %d",retentionTimeMillis);
+                                "retention time must be positive, was %d", retentionTimeMillis);
 
-    this.delegate = Preconditions.checkNotNull(delegate, "delegate");
+    this.delegate = requireNonNull(delegate, "delegate");
     cache = CacheBuilder.newBuilder()
         .expireAfterWrite(retentionTimeMillis, TimeUnit.MILLISECONDS)
         .build();
@@ -46,7 +48,7 @@ class RetainingDnsSrvResolver implements DnsSrvResolver {
 
   @Override
   public List<LookupResult> resolve(final String fqdn) {
-    Preconditions.checkNotNull(fqdn, "fqdn");
+    requireNonNull(fqdn, "fqdn");
 
     try {
       final List<LookupResult> nodes = delegate.resolve(fqdn);

--- a/src/main/java/com/spotify/dns/RetainingDnsSrvResolver.java
+++ b/src/main/java/com/spotify/dns/RetainingDnsSrvResolver.java
@@ -16,13 +16,12 @@
 
 package com.spotify.dns;
 
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -67,7 +66,8 @@ class RetainingDnsSrvResolver implements DnsSrvResolver {
         return cache.getIfPresent(fqdn);
       }
 
-      throw Throwables.propagate(e);
+      throwIfUnchecked(e);
+      throw new RuntimeException(e);
     }
   }
 }

--- a/src/main/java/com/spotify/dns/ServiceResolvingChangeNotifier.java
+++ b/src/main/java/com/spotify/dns/ServiceResolvingChangeNotifier.java
@@ -16,16 +16,14 @@
 
 package com.spotify.dns;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A {@link ChangeNotifier} that resolves and provides records using a {@link DnsSrvResolver}.
@@ -41,8 +39,8 @@ class ServiceResolvingChangeNotifier<T> extends AbstractChangeNotifier<T>
   private final String fqdn;
   private final Function<LookupResult, T> resultTransformer;
 
-  @Nullable
   private final ErrorHandler errorHandler;
+
 
   private volatile Set<T> records = ChangeNotifiers.initialEmptyDataInstance();
   private volatile boolean waitingForFirstEvent = true;
@@ -62,12 +60,12 @@ class ServiceResolvingChangeNotifier<T> extends AbstractChangeNotifier<T>
    * @param resolver            The resolver to use.
    * @param fqdn                The name to lookup SRV records for
    * @param resultTransformer   The transform function
-   * @param errorHandler        The error handler that will receive exceptions
+   * @param errorHandler        The error handler that will receive exceptions (nullable)
    */
   ServiceResolvingChangeNotifier(final DnsSrvResolver resolver,
                                  final String fqdn,
                                  final Function<LookupResult, T> resultTransformer,
-                                 @Nullable final ErrorHandler errorHandler) {
+                                 final ErrorHandler errorHandler) {
 
     this.resolver = checkNotNull(resolver);
     this.fqdn = checkNotNull(fqdn, "fqdn");

--- a/src/main/java/com/spotify/dns/ServiceResolvingChangeNotifier.java
+++ b/src/main/java/com/spotify/dns/ServiceResolvingChangeNotifier.java
@@ -41,7 +41,6 @@ class ServiceResolvingChangeNotifier<T> extends AbstractChangeNotifier<T>
 
   private final ErrorHandler errorHandler;
 
-
   private volatile Set<T> records = ChangeNotifiers.initialEmptyDataInstance();
   private volatile boolean waitingForFirstEvent = true;
 

--- a/src/main/java/com/spotify/dns/ServiceResolvingChangeNotifier.java
+++ b/src/main/java/com/spotify/dns/ServiceResolvingChangeNotifier.java
@@ -16,12 +16,12 @@
 
 package com.spotify.dns;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,9 +67,9 @@ class ServiceResolvingChangeNotifier<T> extends AbstractChangeNotifier<T>
                                  final Function<LookupResult, T> resultTransformer,
                                  final ErrorHandler errorHandler) {
 
-    this.resolver = checkNotNull(resolver);
-    this.fqdn = checkNotNull(fqdn, "fqdn");
-    this.resultTransformer = checkNotNull(resultTransformer, "resultTransformer");
+    this.resolver = requireNonNull(resolver, "resolver");
+    this.fqdn = requireNonNull(fqdn, "fqdn");
+    this.resultTransformer = requireNonNull(resultTransformer, "resultTransformer");
     this.errorHandler = errorHandler;
   }
 
@@ -110,7 +110,7 @@ class ServiceResolvingChangeNotifier<T> extends AbstractChangeNotifier<T>
       ImmutableSet.Builder<T> builder = ImmutableSet.builder();
       for (LookupResult node : nodes) {
         T transformed = resultTransformer.apply(node);
-        builder.add(checkNotNull(transformed, "transformed"));
+        builder.add(requireNonNull(transformed, "transformed"));
       }
       current = builder.build();
     } catch (Exception e) {

--- a/src/main/java/com/spotify/dns/XBillDnsSrvResolver.java
+++ b/src/main/java/com/spotify/dns/XBillDnsSrvResolver.java
@@ -16,7 +16,8 @@
 
 package com.spotify.dns;
 
-import com.google.common.base.Preconditions;
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.collect.ImmutableList;
 
 import org.slf4j.Logger;
@@ -33,11 +34,11 @@ import java.util.List;
  */
 class XBillDnsSrvResolver implements DnsSrvResolver {
   private static final Logger LOG = LoggerFactory.getLogger(XBillDnsSrvResolver.class);
-  
+
   private final LookupFactory lookupFactory;
 
   XBillDnsSrvResolver(LookupFactory lookupFactory) {
-    this.lookupFactory = Preconditions.checkNotNull(lookupFactory, "lookupFactory");
+    this.lookupFactory = requireNonNull(lookupFactory, "lookupFactory");
   }
 
   @Override

--- a/src/main/java/com/spotify/dns/statistics/DnsTimingContext.java
+++ b/src/main/java/com/spotify/dns/statistics/DnsTimingContext.java
@@ -19,6 +19,7 @@ package com.spotify.dns.statistics;
 /**
  * Implement to handle timings when performing dns requests.
  */
+@FunctionalInterface
 public interface DnsTimingContext {
   void stop();
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,9 @@
+module com.spotify.dns {
+
+  requires org.dnsjava;
+  requires com.google.common;
+  requires org.slf4j;
+
+  exports com.spotify.dns;
+  exports com.spotify.dns.statistics;
+}

--- a/src/test/java/com/spotify/dns/AbstractChangeNotifierTest.java
+++ b/src/test/java/com/spotify/dns/AbstractChangeNotifierTest.java
@@ -16,18 +16,6 @@
 
 package com.spotify.dns;
 
-import com.google.common.collect.Sets;
-
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
-import java.util.Set;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
@@ -36,6 +24,15 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 public class AbstractChangeNotifierTest {
 
@@ -51,13 +48,13 @@ public class AbstractChangeNotifierTest {
   AbstractChangeNotifier<String> sut;
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     MockitoAnnotations.initMocks(this);
 
-    sut = new AbstractChangeNotifier<String>() {
+    sut = new AbstractChangeNotifier<>() {
       @Override
       public Set<String> current() {
-        return Sets.newHashSet("foo", "bar");
+        return Set.of("foo", "bar");
       }
 
       @Override
@@ -67,7 +64,7 @@ public class AbstractChangeNotifierTest {
   }
 
   @Test
-  public void shouldRegisterListener() throws Exception {
+  public void shouldRegisterListener() {
     sut.setListener(listener, false);
     sut.fireRecordsUpdated(changeNotification);
 
@@ -76,7 +73,7 @@ public class AbstractChangeNotifierTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void shouldNotFireImmediatelyIfFalse() throws Exception {
+  public void shouldNotFireImmediatelyIfFalse() {
     sut.setListener(listener, false);
 
     verify(listener, never()).onChange(any(ChangeNotifier.ChangeNotification.class));
@@ -84,7 +81,7 @@ public class AbstractChangeNotifierTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void shouldFireImmediatelyIfTrue() throws Exception {
+  public void shouldFireImmediatelyIfTrue() {
     sut.setListener(listener, true);
 
     final ArgumentCaptor<ChangeNotifier.ChangeNotification> captor =
@@ -99,7 +96,7 @@ public class AbstractChangeNotifierTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void shouldNotFireAfterClose() throws Exception {
+  public void shouldNotFireAfterClose() {
     sut.setListener(listener, false);
     sut.close();
     sut.fireRecordsUpdated(changeNotification);
@@ -109,7 +106,7 @@ public class AbstractChangeNotifierTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void shouldNotAllowMultipleListeners() throws Exception {
+  public void shouldNotAllowMultipleListeners() {
     sut.setListener(listener, false);
 
     thrown.expect(IllegalStateException.class);
@@ -118,7 +115,7 @@ public class AbstractChangeNotifierTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void shouldIgnoreListenerExceptions() throws Exception {
+  public void shouldIgnoreListenerExceptions() {
     doThrow(new RuntimeException("stupid listener"))
         .when(listener)
         .onChange(any(ChangeNotifier.ChangeNotification.class));

--- a/src/test/java/com/spotify/dns/AggregatingChangeNotifierTest.java
+++ b/src/test/java/com/spotify/dns/AggregatingChangeNotifierTest.java
@@ -15,30 +15,28 @@
  */
 package com.spotify.dns;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import org.junit.Test;
-
-import java.util.Set;
-
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import java.util.List;
+import java.util.Set;
+import org.junit.Test;
+
 public class AggregatingChangeNotifierTest {
   @Test
-  public void testEmptySet() throws Exception {
+  public void testEmptySet() {
     MyNotifier childNotifier = new MyNotifier();
-    AggregatingChangeNotifier<String> notifier = new AggregatingChangeNotifier<String>(ImmutableList.<ChangeNotifier<String>>of(childNotifier));
+    AggregatingChangeNotifier<String> notifier = new AggregatingChangeNotifier<>(List.of(childNotifier));
 
     ChangeNotifier.Listener listener = mock(ChangeNotifier.Listener.class);
     notifier.setListener(listener, false);
 
     verify(listener, never()).onChange(any(ChangeNotifier.ChangeNotification.class));
 
-    childNotifier.set(ImmutableSet.<String>of());
+    childNotifier.set(Set.of());
     verifyNoMoreInteractions(listener);
 
   }

--- a/src/test/java/com/spotify/dns/CachingLookupFactoryTest.java
+++ b/src/test/java/com/spotify/dns/CachingLookupFactoryTest.java
@@ -16,20 +16,18 @@
 
 package com.spotify.dns;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.xbill.DNS.Lookup;
-
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.Before;
+import org.junit.Test;
+import org.xbill.DNS.Lookup;
 
 public class CachingLookupFactoryTest {
   CachingLookupFactory factory;
@@ -50,14 +48,14 @@ public class CachingLookupFactoryTest {
   }
 
   @Test
-  public void shouldReturnResultsFromDelegate() throws Exception {
+  public void shouldReturnResultsFromDelegate() {
     when(delegate.forName("a name")).thenReturn(lookup);
 
     assertThat(factory.forName("a name"), equalTo(lookup));
   }
 
   @Test
-  public void shouldCacheResultsForSubsequentQueries() throws Exception {
+  public void shouldCacheResultsForSubsequentQueries() {
     when(delegate.forName("hej")).thenReturn(lookup, lookup2);
 
     Lookup first = factory.forName("hej");
@@ -67,7 +65,7 @@ public class CachingLookupFactoryTest {
   }
 
   @Test
-  public void shouldReturnDifferentForDifferentQueries() throws Exception {
+  public void shouldReturnDifferentForDifferentQueries() {
     when(delegate.forName("hej")).thenReturn(lookup);
     when(delegate.forName("hopp")).thenReturn(lookup2);
 
@@ -83,12 +81,7 @@ public class CachingLookupFactoryTest {
     factory = new CachingLookupFactory(new SimpleLookupFactory());
 
     Lookup first = factory.forName("hej");
-    Lookup second = executorService.submit(new Callable<Lookup>() {
-      @Override
-      public Lookup call() throws Exception {
-        return factory.forName("hej");
-      }
-    }).get();
+    Lookup second = executorService.submit(() -> factory.forName("hej")).get();
 
     assertThat(second, not(equalTo(first)));
   }

--- a/src/test/java/com/spotify/dns/DnsSrvWatchersTest.java
+++ b/src/test/java/com/spotify/dns/DnsSrvWatchersTest.java
@@ -1,18 +1,15 @@
 package com.spotify.dns;
 
-import com.google.common.collect.ImmutableList;
-
-import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
 
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.is;
+import org.junit.Test;
 
 public class DnsSrvWatchersTest {
 
@@ -28,7 +25,7 @@ public class DnsSrvWatchersTest {
     final DnsSrvResolver srvResolver = new FakeResolver(
         "horse.sto3.spotify.net", LookupResult.create("localhost", 1, 0, 0, 0));
 
-    final AtomicReference<Set<LookupResult>> hosts = new AtomicReference<Set<LookupResult>>();
+    final AtomicReference<Set<LookupResult>> hosts = new AtomicReference<>();
     final CountDownLatch latch = new CountDownLatch(1);
 
     final ChangeNotifier.Listener<LookupResult> listener = new FakeListener(hosts, latch);
@@ -80,7 +77,7 @@ public class DnsSrvWatchersTest {
     @Override
     public List<LookupResult> resolve(String fqdn) {
       if (this.fqdn.equals(fqdn)) {
-        return ImmutableList.of(result);
+        return List.of(result);
       } else {
         return null;
       }

--- a/src/test/java/com/spotify/dns/DnsTestUtil.java
+++ b/src/test/java/com/spotify/dns/DnsTestUtil.java
@@ -16,25 +16,17 @@
 
 package com.spotify.dns;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
-
-import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Utility functions that are shared between tests.
  */
 public class DnsTestUtil {
   static List<LookupResult> nodes(String... nodeNames) {
-    return Lists.transform(
-        Arrays.asList(nodeNames),
-        new Function<String, LookupResult>() {
-          @Override
-          public LookupResult apply(String input) {
-            return LookupResult.create(input, 8080, 1, 2, 999);
-          }
-        }
-    );
+    return Stream.of(nodeNames)
+        .map(input -> LookupResult.create(input, 8080, 1, 2, 999))
+        .collect(Collectors.toList());
   }
 }

--- a/src/test/java/com/spotify/dns/MeteredDnsSrvResolverTest.java
+++ b/src/test/java/com/spotify/dns/MeteredDnsSrvResolverTest.java
@@ -16,21 +16,19 @@
 
 package com.spotify.dns;
 
-import com.spotify.dns.statistics.DnsReporter;
-import com.spotify.dns.statistics.DnsTimingContext;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.List;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import com.spotify.dns.statistics.DnsReporter;
+import com.spotify.dns.statistics.DnsTimingContext;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 public class MeteredDnsSrvResolverTest {
   private static final String FQDN = "nånting";

--- a/src/test/java/com/spotify/dns/RetainingDnsSrvResolverTest.java
+++ b/src/test/java/com/spotify/dns/RetainingDnsSrvResolverTest.java
@@ -16,19 +16,18 @@
 
 package com.spotify.dns;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
-import java.util.List;
-
 import static com.spotify.dns.DnsTestUtil.nodes;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class RetainingDnsSrvResolverTest {
   private static final String FQDN = "heythere";
@@ -45,7 +44,7 @@ public class RetainingDnsSrvResolverTest {
   public ExpectedException thrown = ExpectedException.none();
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     delegate = mock(DnsSrvResolver.class);
 
     resolver = new RetainingDnsSrvResolver(delegate, RETENTION_TIME_MILLIS);
@@ -55,14 +54,14 @@ public class RetainingDnsSrvResolverTest {
   }
 
   @Test
-  public void shouldReturnResultsFromDelegate() throws Exception {
+  public void shouldReturnResultsFromDelegate() {
     when(delegate.resolve(FQDN)).thenReturn(nodes1);
 
     assertThat(resolver.resolve(FQDN), equalTo(nodes1));
   }
 
   @Test
-  public void shouldReturnResultsFromDelegateEachTime() throws Exception {
+  public void shouldReturnResultsFromDelegateEachTime() {
     when(delegate.resolve(FQDN)).thenReturn(nodes1).thenReturn(nodes2);
 
     resolver.resolve(FQDN);
@@ -71,7 +70,7 @@ public class RetainingDnsSrvResolverTest {
   }
 
   @Test
-  public void shouldRetainDataIfNewResultEmpty() throws Exception {
+  public void shouldRetainDataIfNewResultEmpty() {
     when(delegate.resolve(FQDN)).thenReturn(nodes1).thenReturn(nodes());
 
     resolver.resolve(FQDN);
@@ -80,7 +79,7 @@ public class RetainingDnsSrvResolverTest {
   }
 
   @Test
-  public void shouldRetainDataOnFailure() throws Exception {
+  public void shouldRetainDataOnFailure() {
     when(delegate.resolve(FQDN))
         .thenReturn(nodes1)
         .thenThrow(new DnsException("expected"));
@@ -91,7 +90,7 @@ public class RetainingDnsSrvResolverTest {
   }
 
   @Test
-  public void shouldThrowOnFailureAndNoDataAvailable() throws Exception {
+  public void shouldThrowOnFailureAndNoDataAvailable() {
     when(delegate.resolve(FQDN)).thenThrow(new DnsException("expected"));
 
     thrown.expect(DnsException.class);
@@ -101,14 +100,14 @@ public class RetainingDnsSrvResolverTest {
   }
 
   @Test
-  public void shouldReturnEmptyOnEmptyAndNoDataAvailable() throws Exception {
+  public void shouldReturnEmptyOnEmptyAndNoDataAvailable() {
     when(delegate.resolve(FQDN)).thenReturn(nodes());
 
     assertThat(resolver.resolve(FQDN).isEmpty(), is(true));
   }
 
   @Test
-  public void shouldNotStoreEmptyResults() throws Exception {
+  public void shouldNotStoreEmptyResults() {
     when(delegate.resolve(FQDN))
         .thenReturn(nodes())
         .thenThrow(new DnsException("expected"));
@@ -153,7 +152,7 @@ public class RetainingDnsSrvResolverTest {
   }
 
   @Test
-  public void shouldThrowIfRetentionNegative() throws Exception {
+  public void shouldThrowIfRetentionNegative() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("-4787");
 

--- a/src/test/java/com/spotify/dns/ServiceResolvingChangeNotifierTest.java
+++ b/src/test/java/com/spotify/dns/ServiceResolvingChangeNotifierTest.java
@@ -27,8 +27,6 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.List;
 
-import javax.annotation.Nullable;
-
 import static com.google.common.collect.ImmutableList.of;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -235,9 +233,8 @@ public class ServiceResolvingChangeNotifierTest {
 
   private ChangeNotifierFactory.RunnableChangeNotifier<String> createHostNotifier() {
     return createTransformingNotifier(new Function<LookupResult, String>() {
-      @Nullable
       @Override
-      public String apply(@Nullable LookupResult input) {
+      public String apply(LookupResult input) {
         return input != null ? input.host() : null;
       }
     });

--- a/src/test/java/com/spotify/dns/ServiceResolvingChangeNotifierTest.java
+++ b/src/test/java/com/spotify/dns/ServiceResolvingChangeNotifierTest.java
@@ -16,16 +16,7 @@
 
 package com.spotify.dns;
 
-import java.util.function.Function;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
-import java.util.List;
-
-import static com.google.common.collect.ImmutableList.of;
+import static java.util.List.of;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
@@ -38,6 +29,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+import java.util.function.Function;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
 public class ServiceResolvingChangeNotifierTest {
 
   private static final String FQDN = "example.com";
@@ -49,13 +48,13 @@ public class ServiceResolvingChangeNotifierTest {
   ErrorHandler errorHandler;
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     MockitoAnnotations.initMocks(this);
   }
 
   @Test
   @SuppressWarnings("unchecked")
-  public void shouldCallListenerOnChange() throws Exception {
+  public void shouldCallListenerOnChange() {
     ChangeNotifierFactory.RunnableChangeNotifier<LookupResult> sut = createNotifier();
     ChangeNotifier.Listener<LookupResult> listener = mock(ChangeNotifier.Listener.class);
     sut.setListener(listener, false);
@@ -89,7 +88,7 @@ public class ServiceResolvingChangeNotifierTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void shouldCallListenerOnSet() throws Exception {
+  public void shouldCallListenerOnSet() {
     ChangeNotifierFactory.RunnableChangeNotifier<LookupResult> sut = createNotifier();
     ChangeNotifier.Listener<LookupResult> listener = mock(ChangeNotifier.Listener.class);
 
@@ -112,7 +111,7 @@ public class ServiceResolvingChangeNotifierTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void shouldReturnImmutableSets() throws Exception {
+  public void shouldReturnImmutableSets() {
     ChangeNotifierFactory.RunnableChangeNotifier<LookupResult> sut = createNotifier();
     ChangeNotifier.Listener<LookupResult> listener = mock(ChangeNotifier.Listener.class);
 
@@ -145,7 +144,7 @@ public class ServiceResolvingChangeNotifierTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void shouldOnlyChangeIfTransformedValuesChange() throws Exception {
+  public void shouldOnlyChangeIfTransformedValuesChange() {
     ChangeNotifierFactory.RunnableChangeNotifier<String> sut = createHostNotifier();
     ChangeNotifier.Listener<String> listener = mock(ChangeNotifier.Listener.class);
     sut.setListener(listener, false);
@@ -170,7 +169,7 @@ public class ServiceResolvingChangeNotifierTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void shouldStopResolvingAfterClose() throws Exception {
+  public void shouldStopResolvingAfterClose() {
     ChangeNotifierFactory.RunnableChangeNotifier<LookupResult> sut = createNotifier();
     ChangeNotifier.Listener<LookupResult> listener = mock(ChangeNotifier.Listener.class);
     sut.setListener(listener, false);
@@ -184,7 +183,7 @@ public class ServiceResolvingChangeNotifierTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void shouldDoSomethingWithNulls() throws Exception {
+  public void shouldDoSomethingWithNulls() {
     Function<LookupResult, String> f = mock(Function.class);
     ChangeNotifierFactory.RunnableChangeNotifier<String> sut = createTransformingNotifier(f);
     ChangeNotifier.Listener<String> listener = mock(ChangeNotifier.Listener.class);
@@ -207,7 +206,7 @@ public class ServiceResolvingChangeNotifierTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void shouldCallErrorHandlerOnResolveErrors() throws Exception {
+  public void shouldCallErrorHandlerOnResolveErrors() {
     Function<LookupResult, String> f = mock(Function.class);
     ChangeNotifierFactory.RunnableChangeNotifier<String> sut = createTransformingNotifier(f);
     ChangeNotifier.Listener<String> listener = mock(ChangeNotifier.Listener.class);

--- a/src/test/java/com/spotify/dns/ServiceResolvingChangeNotifierTest.java
+++ b/src/test/java/com/spotify/dns/ServiceResolvingChangeNotifierTest.java
@@ -16,9 +16,7 @@
 
 package com.spotify.dns;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
-
+import java.util.function.Function;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -228,16 +226,11 @@ public class ServiceResolvingChangeNotifierTest {
   }
 
   private ChangeNotifierFactory.RunnableChangeNotifier<LookupResult> createNotifier() {
-    return createTransformingNotifier(Functions.<LookupResult>identity());
+    return createTransformingNotifier(Function.identity());
   }
 
   private ChangeNotifierFactory.RunnableChangeNotifier<String> createHostNotifier() {
-    return createTransformingNotifier(new Function<LookupResult, String>() {
-      @Override
-      public String apply(LookupResult input) {
-        return input != null ? input.host() : null;
-      }
-    });
+    return createTransformingNotifier(input -> input != null ? input.host() : null);
   }
 
   private <T> ChangeNotifierFactory.RunnableChangeNotifier<T> createTransformingNotifier(

--- a/src/test/java/com/spotify/dns/SimpleLookupFactoryTest.java
+++ b/src/test/java/com/spotify/dns/SimpleLookupFactoryTest.java
@@ -16,17 +16,17 @@
 
 package com.spotify.dns;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.isA;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.xbill.DNS.Lookup;
 import org.xbill.DNS.TextParseException;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.isA;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 
 public class SimpleLookupFactoryTest {
@@ -36,17 +36,17 @@ public class SimpleLookupFactoryTest {
   public ExpectedException thrown = ExpectedException.none();
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     factory = new SimpleLookupFactory();
   }
 
   @Test
-  public void shouldCreateLookups() throws Exception {
+  public void shouldCreateLookups() {
     assertThat(factory.forName("some.domain."), is(notNullValue()));
   }
 
   @Test
-  public void shouldCreateNewLookupsEachTime() throws Exception {
+  public void shouldCreateNewLookupsEachTime() {
     Lookup first = factory.forName("some.other.name.");
     Lookup second = factory.forName("some.other.name.");
 
@@ -54,7 +54,7 @@ public class SimpleLookupFactoryTest {
   }
 
   @Test
-  public void shouldRethrowXBillExceptions() throws Exception {
+  public void shouldRethrowXBillExceptions() {
     thrown.expect(DnsException.class);
     thrown.expectCause(isA(TextParseException.class));
 

--- a/src/test/java/com/spotify/dns/examples/BasicUsage.java
+++ b/src/test/java/com/spotify/dns/examples/BasicUsage.java
@@ -22,7 +22,6 @@ import com.spotify.dns.DnsSrvResolvers;
 import com.spotify.dns.LookupResult;
 import com.spotify.dns.statistics.DnsReporter;
 import com.spotify.dns.statistics.DnsTimingContext;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;

--- a/src/test/java/com/spotify/dns/examples/PollingUsage.java
+++ b/src/test/java/com/spotify/dns/examples/PollingUsage.java
@@ -17,7 +17,6 @@
 package com.spotify.dns.examples;
 
 import com.google.common.collect.Sets;
-
 import com.spotify.dns.ChangeNotifier;
 import com.spotify.dns.DnsException;
 import com.spotify.dns.DnsSrvResolver;
@@ -26,7 +25,6 @@ import com.spotify.dns.DnsSrvWatcher;
 import com.spotify.dns.DnsSrvWatchers;
 import com.spotify.dns.ErrorHandler;
 import com.spotify.dns.LookupResult;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;


### PR DESCRIPTION
This was prompted by me trying to modularize another library that transitively dependeds on `dns-java`. I ran into an issue when importing this as an automatic module, caused by `dnsjava` [containing classes in the default/unnamed package](https://github.com/dnsjava/dnsjava/tree/v2.1.9):

```
[WARNING] Can't extract module name from dnsjava-2.1.8.jar: lookup.class found in top-level directory (unnamed package not allowed in module)
```

These are removed in version 3.0.0

### Upgrading dnsjava to 3.x
Although the [readme](https://github.com/dnsjava/dnsjava#migrating-from-version-21x-to-v3) mentions that a lot of things has changed, we seem to be in the clear since we're using such a small portion of the API (`Lookup`, `Record` and `SRVRecord`)

### Upgrade to Java 9
Java 9 was released September 2017. It should not be a controversial requirement. Also, given the level of stability in this library, it would be safe to continue using v3.1.5 for users still on Java 8.

### Dropping jsr305
The value of these annotations where minimal. A small price to pay for enabling modules. cc #33

---

This PR should make #36 redundant