### PR TITLE
Use LookupSession for async lookups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>dnsjava</groupId>
             <artifactId>dnsjava</artifactId>
-            <version>3.0.2</version>
+            <version>3.4.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/src/main/java/com/spotify/dns/CachingLookupFactory.java
+++ b/src/main/java/com/spotify/dns/CachingLookupFactory.java
@@ -1,54 +1,54 @@
-/*
- * Copyright (c) 2015 Spotify AB
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-package com.spotify.dns;
-
-import static java.util.Objects.requireNonNull;
-
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.util.concurrent.UncheckedExecutionException;
-import java.util.concurrent.ExecutionException;
-import org.xbill.DNS.Lookup;
-
-/**
- * Caches Lookup instances using a per-thread cache; this is so that different threads will never
- * get the same instance of Lookup. Lookup instances are not thread-safe.
- */
-class CachingLookupFactory implements LookupFactory {
-  private final LookupFactory delegate;
-  private final ThreadLocal<Cache<String, Lookup>> cacheHolder;
-
-  CachingLookupFactory(LookupFactory delegate) {
-    this.delegate = requireNonNull(delegate, "delegate");
-    cacheHolder =
-        ThreadLocal.withInitial(() -> CacheBuilder.newBuilder().build());
-  }
-
-  @Override
-  public Lookup forName(final String fqdn) {
-    try {
-      return cacheHolder.get().get(
-          fqdn,
-          () -> delegate.forName(fqdn)
-      );
-    } catch (ExecutionException e) {
-      throw new DnsException(e);
-    } catch (UncheckedExecutionException e) {
-      throw new DnsException(e);
-    }
-  }
-}
+///*
+// * Copyright (c) 2015 Spotify AB
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//
+//package com.spotify.dns;
+//
+//import static java.util.Objects.requireNonNull;
+//
+//import com.google.common.cache.Cache;
+//import com.google.common.cache.CacheBuilder;
+//import com.google.common.util.concurrent.UncheckedExecutionException;
+//import java.util.concurrent.ExecutionException;
+//import org.xbill.DNS.Lookup;
+//
+///**
+// * Caches Lookup instances using a per-thread cache; this is so that different threads will never
+// * get the same instance of Lookup. Lookup instances are not thread-safe.
+// */
+//class CachingLookupFactory implements LookupFactory {
+//  private final LookupFactory delegate;
+//  private final ThreadLocal<Cache<String, Lookup>> cacheHolder;
+//
+//  CachingLookupFactory(LookupFactory delegate) {
+//    this.delegate = requireNonNull(delegate, "delegate");
+//    cacheHolder =
+//        ThreadLocal.withInitial(() -> CacheBuilder.newBuilder().build());
+//  }
+//
+//  @Override
+//  public Lookup forName(final String fqdn) {
+//    try {
+//      return cacheHolder.get().get(
+//          fqdn,
+//          () -> delegate.forName(fqdn)
+//      );
+//    } catch (ExecutionException e) {
+//      throw new DnsException(e);
+//    } catch (UncheckedExecutionException e) {
+//      throw new DnsException(e);
+//    }
+//  }
+//}

--- a/src/main/java/com/spotify/dns/DnsSrvResolver.java
+++ b/src/main/java/com/spotify/dns/DnsSrvResolver.java
@@ -17,6 +17,7 @@
 package com.spotify.dns;
 
 import java.util.List;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Contract for doing SRV lookups.
@@ -30,5 +31,5 @@ public interface DnsSrvResolver {
    * @return a possibly empty list of matching records
    * @throws DnsException if there was an error doing the DNS lookup
    */
-  List<LookupResult> resolve(String fqdn);
+  CompletionStage<List<LookupResult>> resolve(String fqdn);
 }

--- a/src/main/java/com/spotify/dns/DnsSrvResolvers.java
+++ b/src/main/java/com/spotify/dns/DnsSrvResolvers.java
@@ -79,7 +79,7 @@ public final class DnsSrvResolvers {
         // or if that's empty, localhost.
         resolver = servers == null ?
                    new ExtendedResolver() :
-                   new ExtendedResolver(servers.toArray(new String[servers.size()]));
+                   new ExtendedResolver(servers.toArray(new String[0]));
       } catch (UnknownHostException e) {
         throw new RuntimeException(e);
       }
@@ -90,9 +90,9 @@ public final class DnsSrvResolvers {
 
       LookupFactory lookupFactory = new SimpleLookupFactory(resolver);
 
-      if (cacheLookups) {
-        lookupFactory = new CachingLookupFactory(lookupFactory);
-      }
+//      if (cacheLookups) {
+//        lookupFactory = new CachingLookupFactory(lookupFactory);
+//      }
 
       DnsSrvResolver result = new XBillDnsSrvResolver(lookupFactory);
 

--- a/src/main/java/com/spotify/dns/LookupFactory.java
+++ b/src/main/java/com/spotify/dns/LookupFactory.java
@@ -16,16 +16,16 @@
 
 package com.spotify.dns;
 
-import org.xbill.DNS.Lookup;
+import org.xbill.DNS.lookup.LookupSession;
 
 /**
- * Library-internal interface used for finding or creating {@link Lookup} instances.
+ * Library-internal interface used for finding or creating {@link LookupSession} instances.
  */
 interface LookupFactory {
   /**
-   * Returns a {@link Lookup} instance capable of doing SRV lookups for the supplied FQDN.
+   * Returns a {@link LookupSession} instance capable of doing SRV lookups for the supplied FQDN.
    * @param fqdn the name to do lookups for
    * @return a Lookup instance
    */
-  Lookup forName(String fqdn);
+  LookupSession forName(String fqdn);
 }

--- a/src/main/java/com/spotify/dns/RetainingDnsSrvResolver.java
+++ b/src/main/java/com/spotify/dns/RetainingDnsSrvResolver.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import java.util.List;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -46,28 +47,27 @@ class RetainingDnsSrvResolver implements DnsSrvResolver {
   }
 
   @Override
-  public List<LookupResult> resolve(final String fqdn) {
+  public CompletionStage<List<LookupResult>> resolve(final String fqdn) {
     requireNonNull(fqdn, "fqdn");
-
-    try {
-      final List<LookupResult> nodes = delegate.resolve(fqdn);
-
-      // No nodes resolved? Return stale data.
-      if (nodes.isEmpty()) {
-        List<LookupResult> cached = cache.getIfPresent(fqdn);
-        return (cached != null) ? cached : nodes;
+    return delegate.resolve(fqdn).handle((nodes, e) -> {
+      if (e == null){
+        // No nodes resolved? Return stale data.
+        if (nodes.isEmpty()) {
+          List<LookupResult> cached = cache.getIfPresent(fqdn);
+          return (cached != null) ? cached : nodes;
+        }
+  
+        cache.put(fqdn, nodes);
+  
+        return nodes;
+      } else{
+        if (cache.getIfPresent(fqdn) != null) {
+          return cache.getIfPresent(fqdn);
+        }
+  
+        throwIfUnchecked(e);
+        throw new RuntimeException(e);
       }
-
-      cache.put(fqdn, nodes);
-
-      return nodes;
-    } catch (Exception e) {
-      if (cache.getIfPresent(fqdn) != null) {
-        return cache.getIfPresent(fqdn);
-      }
-
-      throwIfUnchecked(e);
-      throw new RuntimeException(e);
-    }
+    });
   }
 }

--- a/src/main/java/com/spotify/dns/SimpleLookupFactory.java
+++ b/src/main/java/com/spotify/dns/SimpleLookupFactory.java
@@ -21,32 +21,22 @@ import org.xbill.DNS.Lookup;
 import org.xbill.DNS.Resolver;
 import org.xbill.DNS.TextParseException;
 import org.xbill.DNS.Type;
+import org.xbill.DNS.lookup.LookupSession;
 
-/**
- * A LookupFactory that always returns new instances.
- */
+/** A LookupFactory that always returns new instances. */
 public class SimpleLookupFactory implements LookupFactory {
-
-  private final Resolver resolver;
+  private final LookupSession session;
 
   public SimpleLookupFactory() {
-    this(null);
+    this(Lookup.getDefaultResolver());
   }
 
   public SimpleLookupFactory(Resolver resolver) {
-    this.resolver = resolver;
+    session = LookupSession.builder().resolver(resolver).build();
   }
 
   @Override
-  public Lookup forName(String fqdn) {
-    try {
-      final Lookup lookup = new Lookup(fqdn, Type.SRV, DClass.IN);
-      if (resolver != null) {
-        lookup.setResolver(resolver);
-      }
-      return lookup;
-    } catch (TextParseException e) {
-      throw new DnsException("unable to create lookup for name: " + fqdn, e);
-    }
+  public LookupSession forName(String fqdn) {
+    return session;
   }
 }

--- a/src/test/java/com/spotify/dns/CachingLookupFactoryTest.java
+++ b/src/test/java/com/spotify/dns/CachingLookupFactoryTest.java
@@ -1,88 +1,88 @@
-/*
- * Copyright (c) 2015 Spotify AB
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-package com.spotify.dns;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import org.junit.Before;
-import org.junit.Test;
-import org.xbill.DNS.Lookup;
-
-public class CachingLookupFactoryTest {
-  CachingLookupFactory factory;
-
-  LookupFactory delegate;
-
-  Lookup lookup;
-  Lookup lookup2;
-
-  @Before
-  public void setUp() throws Exception {
-    delegate = mock(LookupFactory.class);
-
-    factory = new CachingLookupFactory(delegate);
-
-    lookup = new Lookup("hi");
-    lookup2 = new Lookup("hey");
-  }
-
-  @Test
-  public void shouldReturnResultsFromDelegate() {
-    when(delegate.forName("a name")).thenReturn(lookup);
-
-    assertThat(factory.forName("a name"), equalTo(lookup));
-  }
-
-  @Test
-  public void shouldCacheResultsForSubsequentQueries() {
-    when(delegate.forName("hej")).thenReturn(lookup, lookup2);
-
-    Lookup first = factory.forName("hej");
-    Lookup second = factory.forName("hej");
-
-    assertThat(first == second, is(true));
-  }
-
-  @Test
-  public void shouldReturnDifferentForDifferentQueries() {
-    when(delegate.forName("hej")).thenReturn(lookup);
-    when(delegate.forName("hopp")).thenReturn(lookup2);
-
-    Lookup first = factory.forName("hej");
-    Lookup second = factory.forName("hopp");
-
-    assertThat(first == second, is(false));
-  }
-
-  @Test
-  public void shouldReturnDifferentForDifferentThreads() throws Exception {
-    ExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
-    factory = new CachingLookupFactory(new SimpleLookupFactory());
-
-    Lookup first = factory.forName("hej");
-    Lookup second = executorService.submit(() -> factory.forName("hej")).get();
-
-    assertThat(second, not(equalTo(first)));
-  }
-}
+///*
+// * Copyright (c) 2015 Spotify AB
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//
+//package com.spotify.dns;
+//
+//import static org.hamcrest.CoreMatchers.equalTo;
+//import static org.hamcrest.CoreMatchers.is;
+//import static org.hamcrest.CoreMatchers.not;
+//import static org.junit.Assert.assertThat;
+//import static org.mockito.Mockito.mock;
+//import static org.mockito.Mockito.when;
+//
+//import java.util.concurrent.ExecutorService;
+//import java.util.concurrent.Executors;
+//import org.junit.Before;
+//import org.junit.Test;
+//import org.xbill.DNS.Lookup;
+//
+//public class CachingLookupFactoryTest {
+//  CachingLookupFactory factory;
+//
+//  LookupFactory delegate;
+//
+//  Lookup lookup;
+//  Lookup lookup2;
+//
+//  @Before
+//  public void setUp() throws Exception {
+//    delegate = mock(LookupFactory.class);
+//
+//    factory = new CachingLookupFactory(delegate);
+//
+//    lookup = new Lookup("hi");
+//    lookup2 = new Lookup("hey");
+//  }
+//
+//  @Test
+//  public void shouldReturnResultsFromDelegate() {
+//    when(delegate.forName("a name")).thenReturn(lookup);
+//
+//    assertThat(factory.forName("a name"), equalTo(lookup));
+//  }
+//
+//  @Test
+//  public void shouldCacheResultsForSubsequentQueries() {
+//    when(delegate.forName("hej")).thenReturn(lookup, lookup2);
+//
+//    Lookup first = factory.forName("hej");
+//    Lookup second = factory.forName("hej");
+//
+//    assertThat(first == second, is(true));
+//  }
+//
+//  @Test
+//  public void shouldReturnDifferentForDifferentQueries() {
+//    when(delegate.forName("hej")).thenReturn(lookup);
+//    when(delegate.forName("hopp")).thenReturn(lookup2);
+//
+//    Lookup first = factory.forName("hej");
+//    Lookup second = factory.forName("hopp");
+//
+//    assertThat(first == second, is(false));
+//  }
+//
+//  @Test
+//  public void shouldReturnDifferentForDifferentThreads() throws Exception {
+//    ExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+//    factory = new CachingLookupFactory(new SimpleLookupFactory());
+//
+//    Lookup first = factory.forName("hej");
+//    Lookup second = executorService.submit(() -> factory.forName("hej")).get();
+//
+//    assertThat(second, not(equalTo(first)));
+//  }
+//}

--- a/src/test/java/com/spotify/dns/DnsSrvWatchersTest.java
+++ b/src/test/java/com/spotify/dns/DnsSrvWatchersTest.java
@@ -6,10 +6,13 @@ import static org.hamcrest.Matchers.is;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
+import org.xbill.DNS.lookup.NoSuchDomainException;
 
 public class DnsSrvWatchersTest {
 
@@ -75,11 +78,11 @@ public class DnsSrvWatchersTest {
     }
 
     @Override
-    public List<LookupResult> resolve(String fqdn) {
+    public CompletionStage<List<LookupResult>> resolve(String fqdn) {
       if (this.fqdn.equals(fqdn)) {
-        return List.of(result);
+        return CompletableFuture.completedFuture(List.of(result));
       } else {
-        return null;
+        return CompletableFuture.failedFuture(new DnsException(this.fqdn + " != " + fqdn));
       }
     }
   }

--- a/src/test/java/com/spotify/dns/ServiceResolvingChangeNotifierTest.java
+++ b/src/test/java/com/spotify/dns/ServiceResolvingChangeNotifierTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import org.junit.Before;
 import org.junit.Test;
@@ -62,7 +63,7 @@ public class ServiceResolvingChangeNotifierTest {
     LookupResult result1 = result("host", 1234);
     LookupResult result2 = result("host", 4321);
     when(resolver.resolve(FQDN))
-        .thenReturn(of(result1), of(result1, result2));
+        .thenReturn(CompletableFuture.completedFuture(of(result1)), CompletableFuture.completedFuture(of(result1, result2)));
 
     sut.run();
     sut.run();
@@ -94,7 +95,7 @@ public class ServiceResolvingChangeNotifierTest {
 
     LookupResult result = result("host", 1234);
     when(resolver.resolve(FQDN))
-        .thenReturn(of(result));
+        .thenReturn(CompletableFuture.completedFuture(of(result)));
 
     sut.run();
     sut.setListener(listener, true);
@@ -118,7 +119,7 @@ public class ServiceResolvingChangeNotifierTest {
     LookupResult result1 = result("host", 1234);
     LookupResult result2 = result("host", 4321);
     when(resolver.resolve(FQDN))
-        .thenReturn(of(result1), of(result1, result2));
+        .thenReturn(CompletableFuture.completedFuture(of(result1)), CompletableFuture.completedFuture(of(result1, result2)));
 
     sut.run();
     sut.setListener(listener, true);
@@ -152,7 +153,7 @@ public class ServiceResolvingChangeNotifierTest {
     LookupResult result1 = result("host", 1234);
     LookupResult result2 = result("host", 4321);
     when(resolver.resolve(FQDN))
-        .thenReturn(of(result1), of(result1, result2));
+        .thenReturn(CompletableFuture.completedFuture(of(result1)), CompletableFuture.completedFuture(of(result1, result2)));
 
     sut.run();
     sut.run();
@@ -189,10 +190,10 @@ public class ServiceResolvingChangeNotifierTest {
     ChangeNotifier.Listener<String> listener = mock(ChangeNotifier.Listener.class);
 
     when(resolver.resolve(FQDN))
-        .thenReturn(of(
+        .thenReturn(CompletableFuture.completedFuture(of(
             result("host1", 1234),
             result("host2", 1234),
-            result("host3", 1234)));
+            result("host3", 1234))));
 
     when(f.apply(any(LookupResult.class)))
         .thenReturn("foo", null, "bar");
@@ -213,7 +214,7 @@ public class ServiceResolvingChangeNotifierTest {
 
     DnsException exception = new DnsException("something wrong");
     when(resolver.resolve(FQDN))
-        .thenThrow(exception);
+        .thenReturn(CompletableFuture.failedFuture(exception));
 
     sut.setListener(listener, false);
     sut.run();

--- a/src/test/java/com/spotify/dns/SimpleLookupFactoryTest.java
+++ b/src/test/java/com/spotify/dns/SimpleLookupFactoryTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.xbill.DNS.Lookup;
 import org.xbill.DNS.TextParseException;
+import org.xbill.DNS.lookup.LookupSession;
 
 
 public class SimpleLookupFactoryTest {
@@ -46,18 +47,10 @@ public class SimpleLookupFactoryTest {
   }
 
   @Test
-  public void shouldCreateNewLookupsEachTime() {
-    Lookup first = factory.forName("some.other.name.");
-    Lookup second = factory.forName("some.other.name.");
+  public void shouldNotCreateNewLookupsEachTime() {
+    LookupSession first = factory.forName("some.other.name.");
+    LookupSession second = factory.forName("some.other.name.");
 
-    assertThat(first == second, is(false));
-  }
-
-  @Test
-  public void shouldRethrowXBillExceptions() {
-    thrown.expect(DnsException.class);
-    thrown.expectCause(isA(TextParseException.class));
-
-    factory.forName("bad\\1 name");
+    assertThat(first == second, is(true));
   }
 }

--- a/src/test/java/com/spotify/dns/examples/BasicUsage.java
+++ b/src/test/java/com/spotify/dns/examples/BasicUsage.java
@@ -16,7 +16,6 @@
 
 package com.spotify.dns.examples;
 
-import com.spotify.dns.DnsException;
 import com.spotify.dns.DnsSrvResolver;
 import com.spotify.dns.DnsSrvResolvers;
 import com.spotify.dns.LookupResult;
@@ -25,7 +24,6 @@ import com.spotify.dns.statistics.DnsTimingContext;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.List;
 
 public final class BasicUsage {
 
@@ -49,15 +47,15 @@ public final class BasicUsage {
       if (line == null || line.isEmpty()) {
         quit = true;
       } else {
-        try {
-          List<LookupResult> nodes = resolver.resolve(line);
-
-          for (LookupResult node : nodes) {
-            System.out.println(node);
+        resolver.resolve(line).whenComplete((nodes, e) -> {
+          if (e == null) {
+            for (LookupResult node : nodes) {
+              System.out.println(node);
+            }
+          } else {
+            e.printStackTrace(System.out);
           }
-        } catch (DnsException e) {
-          e.printStackTrace(System.out);
-        }
+        });
       }
     }
   }


### PR DESCRIPTION
@klaraward This is a rather naive attempt at refactoring this project to use dnsjava's `LookupSession`. See the discussion in dnsjava/dnsjava#211. It breaks some API which probably shouldn't be public anyway, needs further refactoring because e.g. `LookupFactory` doesn't make sense anymore (because LookupSession is thread-safe), and the unit tests need some work (e.g. move to JUnit 5).