### PR TITLE
Use LookupSession for async lookups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,9 +242,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <release>9</release>
-                    <source>9</source>
-                    <target>9</target>
+                    <release>8</release>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>dnsjava</groupId>
             <artifactId>dnsjava</artifactId>
-            <version>3.0.2</version>
+            <version>3.4.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <version>1.7.32</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/com/spotify/dns/CachingLookupFactory.java
+++ b/src/main/java/com/spotify/dns/CachingLookupFactory.java
@@ -23,11 +23,13 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.util.concurrent.ExecutionException;
 import org.xbill.DNS.Lookup;
+import org.xbill.DNS.lookup.LookupSession;
 
 /**
  * Caches Lookup instances using a per-thread cache; this is so that different threads will never
  * get the same instance of Lookup. Lookup instances are not thread-safe.
  */
+@Deprecated
 class CachingLookupFactory implements LookupFactory {
   private final LookupFactory delegate;
   private final ThreadLocal<Cache<String, Lookup>> cacheHolder;
@@ -50,5 +52,10 @@ class CachingLookupFactory implements LookupFactory {
     } catch (UncheckedExecutionException e) {
       throw new DnsException(e);
     }
+  }
+
+  @Override
+  public LookupSession sessionForName(String fqdn) {
+    throw new java.lang.UnsupportedOperationException("Session not supported with caching lookup");
   }
 }

--- a/src/main/java/com/spotify/dns/DnsSrvResolver.java
+++ b/src/main/java/com/spotify/dns/DnsSrvResolver.java
@@ -17,6 +17,7 @@
 package com.spotify.dns;
 
 import java.util.List;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Contract for doing SRV lookups.
@@ -25,10 +26,24 @@ public interface DnsSrvResolver {
   /**
    * Does a DNS SRV lookup for the supplied fully qualified domain name, and returns the
    * matching results.
+   * @deprecated
+   * This method is deprecated in favor of the asynchronous version.
+   * Use {@link DnsSrvResolver#resolveAsync(String)} instead
    *
    * @param fqdn a DNS name to query for
    * @return a possibly empty list of matching records
    * @throws DnsException if there was an error doing the DNS lookup
    */
+  @Deprecated
   List<LookupResult> resolve(String fqdn);
+
+  /**
+   * Does a DNS SRV lookup for the supplied fully qualified domain name, and returns the
+   * matching results.
+   *
+   * @param fqdn a DNS name to query for
+   * @return a possibly empty list of matching records
+   * @throws DnsException if there was an error doing the DNS lookup
+   */
+  CompletionStage<List<LookupResult>> resolveAsync(String fqdn);
 }

--- a/src/main/java/com/spotify/dns/LookupFactory.java
+++ b/src/main/java/com/spotify/dns/LookupFactory.java
@@ -17,15 +17,28 @@
 package com.spotify.dns;
 
 import org.xbill.DNS.Lookup;
+import org.xbill.DNS.lookup.LookupSession;
 
 /**
- * Library-internal interface used for finding or creating {@link Lookup} instances.
+ * Library-internal interface used for finding or creating {@link LookupSession} or {@link Lookup} instances.
  */
 interface LookupFactory {
   /**
    * Returns a {@link Lookup} instance capable of doing SRV lookups for the supplied FQDN.
+   * @deprecated
+   * This synchronous method is being deprecated.
+   * Use {@link LookupFactory#sessionForName(String)} instead
+   *
    * @param fqdn the name to do lookups for
    * @return a Lookup instance
    */
+  @Deprecated
   Lookup forName(String fqdn);
+
+  /**
+   * Returns a {@link LookupSession} instance capable of doing SRV lookups for the supplied FQDN.
+   * @param fqdn the name to do lookups for
+   * @return a Lookup instance
+   */
+  LookupSession sessionForName(String fqdn);
 }

--- a/src/main/java/com/spotify/dns/MeteredDnsSrvResolver.java
+++ b/src/main/java/com/spotify/dns/MeteredDnsSrvResolver.java
@@ -16,12 +16,14 @@
 
 package com.spotify.dns;
 
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.util.Objects.requireNonNull;
 
 import com.spotify.dns.statistics.DnsReporter;
 import com.spotify.dns.statistics.DnsTimingContext;
 
 import java.util.List;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Tracks metrics for DnsSrvResolver calls.
@@ -35,28 +37,54 @@ class MeteredDnsSrvResolver implements DnsSrvResolver {
     this.reporter = requireNonNull(reporter, "reporter");
   }
 
+    @Override
+    public List<LookupResult> resolve(String fqdn) {
+        // Only catch and report RuntimeException to avoid Error's since that would
+        // most likely only aggravate any condition that causes them to be thrown.
+
+        final DnsTimingContext resolveTimer = reporter.resolveTimer();
+
+        final List<LookupResult> result;
+
+        try {
+            result = delegate.resolve(fqdn);
+        } catch (RuntimeException error) {
+            reporter.reportFailure(error);
+            throw error;
+        } finally {
+            resolveTimer.stop();
+        }
+
+        if (result.isEmpty()) {
+            reporter.reportEmpty();
+        }
+
+        return result;
+    }
+
   @Override
-  public List<LookupResult> resolve(String fqdn) {
+  public CompletionStage<List<LookupResult>> resolveAsync(String fqdn) {
     // Only catch and report RuntimeException to avoid Error's since that would
     // most likely only aggravate any condition that causes them to be thrown.
 
     final DnsTimingContext resolveTimer = reporter.resolveTimer();
 
-    final List<LookupResult> result;
+    return delegate
+        .resolveAsync(fqdn)
+        .handle(
+            (result, error) -> {
+              resolveTimer.stop();
+              if (error == null) {
+                if (result.isEmpty()) {
+                  reporter.reportEmpty();
+                }
 
-    try {
-      result = delegate.resolve(fqdn);
-    } catch (RuntimeException error) {
-      reporter.reportFailure(error);
-      throw error;
-    } finally {
-      resolveTimer.stop();
-    }
-
-    if (result.isEmpty()) {
-      reporter.reportEmpty();
-    }
-
-    return result;
+                return result;
+              } else {
+                reporter.reportFailure(error);
+                throwIfUnchecked(error);
+                throw new RuntimeException(error);
+              }
+            });
   }
 }

--- a/src/main/java/com/spotify/dns/ServiceResolvingChangeNotifier.java
+++ b/src/main/java/com/spotify/dns/ServiceResolvingChangeNotifier.java
@@ -19,7 +19,6 @@ package com.spotify.dns;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableSet;
-import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -53,7 +52,7 @@ class ServiceResolvingChangeNotifier<T> extends AbstractChangeNotifier<T>
    * and put into a set. The set will then be compared to the previous set and if a
    * change is detected, the notifier will fire.
    *
-   * <p>An optional {@link ErrorHandler} can be used to reacto on {@link DnsException}s thrown
+   * <p>An optional {@link ErrorHandler} can be used to react on {@link DnsException}s thrown
    * by the {@link DnsSrvResolver}.
    *
    * @param resolver            The resolver to use.
@@ -88,45 +87,42 @@ class ServiceResolvingChangeNotifier<T> extends AbstractChangeNotifier<T>
       return;
     }
 
-    final List<LookupResult> nodes;
-    try {
-      nodes = resolver.resolve(fqdn);
-    } catch (DnsException e) {
-      if (errorHandler != null) {
-        errorHandler.handle(fqdn, e);
+    resolver.resolveAsync(fqdn).whenComplete((nodes, e) -> {
+      if (e instanceof DnsException) {
+        if (errorHandler != null) {
+          errorHandler.handle(fqdn, (DnsException) e);
+        }
+        log.error(e.getMessage(), e);
+        fireIfFirstError();
+      } else if (e != null) {
+        log.error(e.getMessage(), e);
+        fireIfFirstError();
+      } else {
+        final Set<T> current;
+        try {
+          ImmutableSet.Builder<T> builder = ImmutableSet.builder();
+          for (LookupResult node : nodes) {
+            T transformed = resultTransformer.apply(node);
+            builder.add(requireNonNull(transformed, "transformed"));
+          }
+          current = builder.build();
+        } catch (Exception transformerException) {
+          log.error(transformerException.getMessage(), transformerException);
+          fireIfFirstError();
+          return;
+        }
+
+        if (ChangeNotifiers.isNoLongerInitial(current, records) || !current.equals(records)) {
+          // This means that any subsequent DNS error will be ignored and the existing result will be kept
+          waitingForFirstEvent = false;
+          final ChangeNotification<T> changeNotification =
+                  newChangeNotification(current, records);
+          records = current;
+
+          fireRecordsUpdated(changeNotification);
+        }
       }
-      log.error(e.getMessage(), e);
-      fireIfFirstError();
-      return;
-    } catch (Exception e) {
-      log.error(e.getMessage(), e);
-      fireIfFirstError();
-      return;
-    }
-
-    final Set<T> current;
-    try {
-      ImmutableSet.Builder<T> builder = ImmutableSet.builder();
-      for (LookupResult node : nodes) {
-        T transformed = resultTransformer.apply(node);
-        builder.add(requireNonNull(transformed, "transformed"));
-      }
-      current = builder.build();
-    } catch (Exception e) {
-      log.error(e.getMessage(), e);
-      fireIfFirstError();
-      return;
-    }
-
-    if (ChangeNotifiers.isNoLongerInitial(current, records) || !current.equals(records)) {
-      // This means that any subsequent DNS error will be ignored and the existing result will be kept
-      waitingForFirstEvent = false;
-      final ChangeNotification<T> changeNotification =
-          newChangeNotification(current, records);
-      records = current;
-
-      fireRecordsUpdated(changeNotification);
-    }
+    });
   }
 
   private void fireIfFirstError() {

--- a/src/main/java/com/spotify/dns/XBillDnsSrvResolver.java
+++ b/src/main/java/com/spotify/dns/XBillDnsSrvResolver.java
@@ -22,15 +22,24 @@ import com.google.common.collect.ImmutableList;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xbill.DNS.DClass;
 import org.xbill.DNS.Lookup;
+import org.xbill.DNS.Name;
 import org.xbill.DNS.Record;
 import org.xbill.DNS.SRVRecord;
+import org.xbill.DNS.TextParseException;
+import org.xbill.DNS.Type;
+import org.xbill.DNS.lookup.LookupSession;
+import org.xbill.DNS.lookup.NoSuchDomainException;
+import org.xbill.DNS.lookup.NoSuchRRSetException;
 
 import java.util.List;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
 
 /**
- * A DnsSrvResolver implementation that uses the dnsjava implementation from xbill.org:
- * http://www.xbill.org/dnsjava/
+ * A DnsSrvResolver implementation that uses the dnsjava implementation:
+ * https://github.com/dnsjava/dnsjava
  */
 class XBillDnsSrvResolver implements DnsSrvResolver {
   private static final Logger LOG = LoggerFactory.getLogger(XBillDnsSrvResolver.class);
@@ -53,27 +62,73 @@ class XBillDnsSrvResolver implements DnsSrvResolver {
         // fallthrough
       case Lookup.TYPE_NOT_FOUND:
         LOG.warn("No results returned for query '{}'; result from XBill: {} - {}",
-            fqdn, lookup.getResult(), lookup.getErrorString());
+                fqdn, lookup.getResult(), lookup.getErrorString());
         return ImmutableList.of();
       default:
         throw new DnsException(
-            String.format("Lookup of '%s' failed with code: %d - %s ",
-                fqdn, lookup.getResult(), lookup.getErrorString()));
+                String.format("Lookup of '%s' failed with code: %d - %s ",
+                        fqdn, lookup.getResult(), lookup.getErrorString()));
     }
+  }
+
+  @Override
+  public CompletionStage<List<LookupResult>> resolveAsync(final String fqdn) {
+    LookupSession lookup = lookupFactory.sessionForName(fqdn);
+    Name name;
+    try {
+      name = Name.fromString(fqdn);
+    } catch (TextParseException e) {
+      throw new DnsException("unable to create lookup for name: " + fqdn, e);
+    }
+
+    return lookup.lookupAsync(name, Type.SRV, DClass.IN).handle((result, ex) ->{
+      if (ex == null){
+        return toLookupResults(result);
+      } else{
+        Throwable cause = ex;
+        if (ex instanceof CompletionException && ex.getCause() != null) {
+          cause = ex.getCause();
+        }
+        if (cause instanceof NoSuchRRSetException || cause instanceof NoSuchDomainException) {
+          LOG.warn("No results returned for query '{}'; result from dnsjava: {}",
+                  fqdn, ex.getMessage());
+          return ImmutableList.of();
+        }
+        throw new DnsException(
+                String.format("Lookup of '%s' failed: %s ", fqdn, ex.getMessage()), ex);
+      }
+    });
+  }
+
+  private static List<LookupResult> toLookupResults(org.xbill.DNS.lookup.LookupResult queryResult) {
+    ImmutableList.Builder<LookupResult> builder = ImmutableList.builder();
+
+    for (Record record: queryResult.getRecords()) {
+      if (record instanceof SRVRecord) {
+        SRVRecord srvRecord = (SRVRecord) record;
+        builder.add(LookupResult.create(srvRecord.getTarget().toString(),
+                                        srvRecord.getPort(),
+                                        srvRecord.getPriority(),
+                                        srvRecord.getWeight(),
+                                        srvRecord.getTTL()));
+      }
+    }
+
+    return builder.build();
   }
 
   private static List<LookupResult> toLookupResults(Record[] queryResult) {
     ImmutableList.Builder<LookupResult> builder = ImmutableList.builder();
 
     if (queryResult != null) {
-      for (Record record: queryResult) {
+      for (Record record : queryResult) {
         if (record instanceof SRVRecord) {
           SRVRecord srvRecord = (SRVRecord) record;
           builder.add(LookupResult.create(srvRecord.getTarget().toString(),
-                                          srvRecord.getPort(),
-                                          srvRecord.getPriority(),
-                                          srvRecord.getWeight(),
-                                          srvRecord.getTTL()));
+                  srvRecord.getPort(),
+                  srvRecord.getPriority(),
+                  srvRecord.getWeight(),
+                  srvRecord.getTTL()));
         }
       }
     }

--- a/src/test/java/com/spotify/dns/DnsLookupPerformanceTest.java
+++ b/src/test/java/com/spotify/dns/DnsLookupPerformanceTest.java
@@ -1,0 +1,100 @@
+package com.spotify.dns;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class DnsLookupPerformanceTest {
+    private static AtomicInteger successCount = new AtomicInteger(0);
+
+    private static DnsSrvResolver resolver = DnsSrvResolvers.newBuilder()
+            .cachingLookups(false)
+            .retainingDataOnFailures(false)
+            .dnsLookupTimeoutMillis(5000)
+            .executor(Executors.newFixedThreadPool(10))
+            .build();
+
+    @Test
+    @Ignore("Needs network access and is timing dependent")
+    public void runTest() throws InterruptedException {
+        int numThreads = 3;
+        final ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+        List<String> records = List.of(
+                "_spotify-noop._http.services.gew1.spotify.net.",
+                "_spotify-noop._http.services.guc3.spotify.net.",
+                "_spotify-noop._http.services.gae2.spotify.net.",
+                "_spotify-palindrome._grpc.services.gae2.spotify.net.",
+                "_spotify-palindrome._grpc.services.gew1.spotify.net.",
+                "_spotify-concat._grpc.services.gew1.spotify.net.",
+                "_spotify-concat._grpc.services.guc3.spotify.net.",
+                "_spotify-concat._hm.services.gae2.spotify.net.",
+                "_spotify-concat._hm.services.gew1.spotify.net.",
+                "_spotify-concat._hm.services.guc3.spotify.net.",
+                "_spotify-fabric-test._grpc.services.gae2.spotify.net.",
+                "_spotify-fabric-test._grpc.services.gew1.spotify.net.",
+                "_spotify-fabric-test._grpc.services.guc3.spotify.net.",
+                "_spotify-fabric-test._hm.services.gae2.spotify.net.",
+                "_spotify-fabric-test._hm.services.gew1.spotify.net.",
+                "_spotify-fabric-test._hm.services.guc3.spotify.net.",
+                "_spotify-fabric-load-generator._grpc.services.gae2.spotify.net.",
+                "_spotify-fabric-load-generator._grpc.services.gew1.spotify.net.",
+                "_spotify-fabric-load-generator._grpc.services.guc3.spotify.net.",
+                "_spotify-client._tcp.spotify.com");
+
+        CountDownLatch done = new CountDownLatch(records.size() * 2);
+        records.stream()
+                .forEach(
+                        fqdn -> {
+                            executorService.submit(() -> resolve(fqdn, done));
+                            CompletableFuture.runAsync(DnsLookupPerformanceTest::blockCommonPool)
+                                    .whenComplete((v, ex) -> done.countDown());
+                        });
+        done.await(1, TimeUnit.MINUTES);
+        executorService.shutdown();
+
+        int failureCount = records.size() - successCount.get();
+
+        System.out.println("Number of threads: " + numThreads);
+        System.out.println("Number of records: " + records.size());
+        System.out.println("Failed lookups: " + failureCount);
+
+        assertThat(failureCount, equalTo(0));
+    }
+
+    private static void blockCommonPool() {
+        try {
+            Thread.sleep(10_000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void resolve(String fqdn, CountDownLatch done) {
+        try {
+            System.out.println("Resolving: " + fqdn);
+            List<LookupResult> results = resolver.resolveAsync(fqdn).toCompletableFuture().get();
+
+            if(!results.isEmpty()) {
+                successCount.incrementAndGet();
+                System.out.println(fqdn + "...ok!");
+            } else {
+                System.err.format("%s ... failed!\n", fqdn);
+            }
+        } catch (Exception e) {
+            System.err.format("%s ... failed!\n", fqdn);
+            e.printStackTrace(System.err);
+        } finally {
+            done.countDown();
+        }
+    }
+}

--- a/src/test/java/com/spotify/dns/DnsSrvWatchersTest.java
+++ b/src/test/java/com/spotify/dns/DnsSrvWatchersTest.java
@@ -6,10 +6,13 @@ import static org.hamcrest.Matchers.is;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
+import org.xbill.DNS.lookup.NoSuchDomainException;
 
 public class DnsSrvWatchersTest {
 
@@ -80,6 +83,15 @@ public class DnsSrvWatchersTest {
         return List.of(result);
       } else {
         return null;
+      }
+    }
+
+    @Override
+    public CompletionStage<List<LookupResult>> resolveAsync(String fqdn) {
+      if (this.fqdn.equals(fqdn)) {
+        return CompletableFuture.completedFuture(List.of(result));
+      } else {
+        return CompletableFuture.failedFuture(new DnsException(this.fqdn + " != " + fqdn));
       }
     }
   }

--- a/src/test/java/com/spotify/dns/ServiceResolvingChangeNotifierTest.java
+++ b/src/test/java/com/spotify/dns/ServiceResolvingChangeNotifierTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,8 +62,9 @@ public class ServiceResolvingChangeNotifierTest {
 
     LookupResult result1 = result("host", 1234);
     LookupResult result2 = result("host", 4321);
-    when(resolver.resolve(FQDN))
-        .thenReturn(of(result1), of(result1, result2));
+    when(resolver.resolve(FQDN)).thenReturn(of(result1), of(result1, result2));
+    when(resolver.resolveAsync(FQDN))
+        .thenReturn(CompletableFuture.completedFuture(of(result1)), CompletableFuture.completedFuture(of(result1, result2)));
 
     sut.run();
     sut.run();
@@ -94,7 +96,9 @@ public class ServiceResolvingChangeNotifierTest {
 
     LookupResult result = result("host", 1234);
     when(resolver.resolve(FQDN))
-        .thenReturn(of(result));
+            .thenReturn(of(result));
+    when(resolver.resolveAsync(FQDN))
+        .thenReturn(CompletableFuture.completedFuture(of(result)));
 
     sut.run();
     sut.setListener(listener, true);
@@ -118,7 +122,9 @@ public class ServiceResolvingChangeNotifierTest {
     LookupResult result1 = result("host", 1234);
     LookupResult result2 = result("host", 4321);
     when(resolver.resolve(FQDN))
-        .thenReturn(of(result1), of(result1, result2));
+            .thenReturn(of(result1), of(result1, result2));
+    when(resolver.resolveAsync(FQDN))
+        .thenReturn(CompletableFuture.completedFuture(of(result1)), CompletableFuture.completedFuture(of(result1, result2)));
 
     sut.run();
     sut.setListener(listener, true);
@@ -152,7 +158,9 @@ public class ServiceResolvingChangeNotifierTest {
     LookupResult result1 = result("host", 1234);
     LookupResult result2 = result("host", 4321);
     when(resolver.resolve(FQDN))
-        .thenReturn(of(result1), of(result1, result2));
+            .thenReturn(of(result1), of(result1, result2));
+    when(resolver.resolveAsync(FQDN))
+        .thenReturn(CompletableFuture.completedFuture(of(result1)), CompletableFuture.completedFuture(of(result1, result2)));
 
     sut.run();
     sut.run();
@@ -189,10 +197,15 @@ public class ServiceResolvingChangeNotifierTest {
     ChangeNotifier.Listener<String> listener = mock(ChangeNotifier.Listener.class);
 
     when(resolver.resolve(FQDN))
-        .thenReturn(of(
+            .thenReturn(of(
+                    result("host1", 1234),
+                    result("host2", 1234),
+                    result("host3", 1234)));
+    when(resolver.resolveAsync(FQDN))
+        .thenReturn(CompletableFuture.completedFuture(of(
             result("host1", 1234),
             result("host2", 1234),
-            result("host3", 1234)));
+            result("host3", 1234))));
 
     when(f.apply(any(LookupResult.class)))
         .thenReturn("foo", null, "bar");
@@ -213,7 +226,9 @@ public class ServiceResolvingChangeNotifierTest {
 
     DnsException exception = new DnsException("something wrong");
     when(resolver.resolve(FQDN))
-        .thenThrow(exception);
+            .thenThrow(exception);
+    when(resolver.resolveAsync(FQDN))
+        .thenReturn(CompletableFuture.failedFuture(exception));
 
     sut.setListener(listener, false);
     sut.run();

--- a/src/test/java/com/spotify/dns/SimpleLookupFactoryTest.java
+++ b/src/test/java/com/spotify/dns/SimpleLookupFactoryTest.java
@@ -27,6 +27,9 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.xbill.DNS.Lookup;
 import org.xbill.DNS.TextParseException;
+import org.xbill.DNS.lookup.LookupSession;
+
+import java.util.concurrent.ForkJoinPool;
 
 
 public class SimpleLookupFactoryTest {
@@ -37,7 +40,7 @@ public class SimpleLookupFactoryTest {
 
   @Before
   public void setUp() {
-    factory = new SimpleLookupFactory();
+    factory = new SimpleLookupFactory(ForkJoinPool.commonPool());
   }
 
   @Test
@@ -46,7 +49,12 @@ public class SimpleLookupFactoryTest {
   }
 
   @Test
-  public void shouldCreateNewLookupsEachTime() {
+  public void shouldCreateLookupSession() {
+    assertThat(factory.sessionForName("some.domain."), is(notNullValue()));
+  }
+
+  @Test
+  public void shouldNotCreateNewLookupsEachTime() {
     Lookup first = factory.forName("some.other.name.");
     Lookup second = factory.forName("some.other.name.");
 
@@ -54,10 +62,10 @@ public class SimpleLookupFactoryTest {
   }
 
   @Test
-  public void shouldRethrowXBillExceptions() {
-    thrown.expect(DnsException.class);
-    thrown.expectCause(isA(TextParseException.class));
+  public void shouldCreateNewLookupSessionEachTime() {
+    LookupSession firstSession = factory.sessionForName("some.other.name.");
+    LookupSession secondSession = factory.sessionForName("some.other.name.");
 
-    factory.forName("bad\\1 name");
+    assertThat(firstSession == secondSession, is(true));
   }
 }

--- a/src/test/java/com/spotify/dns/examples/BasicUsage.java
+++ b/src/test/java/com/spotify/dns/examples/BasicUsage.java
@@ -16,7 +16,6 @@
 
 package com.spotify.dns.examples;
 
-import com.spotify.dns.DnsException;
 import com.spotify.dns.DnsSrvResolver;
 import com.spotify.dns.DnsSrvResolvers;
 import com.spotify.dns.LookupResult;
@@ -25,7 +24,6 @@ import com.spotify.dns.statistics.DnsTimingContext;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.List;
 
 public final class BasicUsage {
 
@@ -49,15 +47,15 @@ public final class BasicUsage {
       if (line == null || line.isEmpty()) {
         quit = true;
       } else {
-        try {
-          List<LookupResult> nodes = resolver.resolve(line);
-
-          for (LookupResult node : nodes) {
-            System.out.println(node);
+        resolver.resolveAsync(line).whenComplete((nodes, e) -> {
+          if (e == null) {
+            for (LookupResult node : nodes) {
+              System.out.println(node);
+            }
+          } else {
+            e.printStackTrace(System.out);
           }
-        } catch (DnsException e) {
-          e.printStackTrace(System.out);
-        }
+        });
       }
     }
   }


### PR DESCRIPTION
Original PR by @ibauersachs : https://github.com/spotify/dns-java/pull/46
This aims to mitigate performance issue caused by lookups using common forkjoin pool as described in https://github.com/dnsjava/dnsjava/issues/211 .
In `dnsjava` version `3.4.2-SNAPSHOT` @ibauersachs has added support for using custom executors in resolvers https://github.com/dnsjava/dnsjava/commit/dbda6613ff38cfcffb09ca7f76290e77a97b810d
Changes:
- Add asynchronous methods using `LookupSession`
- Allow specifying custom executor in `DnsSrvResolver` builder
- Add performance test (but marked Ignored as the test itself is flaky and timing dependent)

Next steps from Spotify side are:
- Update services/libraries to use async methods with custom executors.
- Remove deprecated methods and remove `LookupFactory` class.