### PR TITLE
Revert "build dns-java with jdk 8"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,9 +242,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <release>8</release>
-                    <source>8</source>
-                    <target>8</target>
+                    <release>9</release>
+                    <source>9</source>
+                    <target>9</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This reverts commit 75583281ae7f6d44c2f8d539e4216683909152ae.
Building the lib with jdk 8 currently leads to this error:
```
/home/sophyc/git/dns-java/src/main/java/module-info.java:[1,1] modules are not supported in -source 8
  (use -source 9 or higher to enable modules)
```
We plan to look into this later and possibly support building the lib with multiple jdk versions,