### PR TITLE
Switch back to jdk 8 compiler and remove java modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,9 +242,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <release>9</release>
-                    <source>9</source>
-                    <target>9</target>
+                    <release>8</release>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/spotify/dns/AbstractChangeNotifier.java
+++ b/src/main/java/com/spotify/dns/AbstractChangeNotifier.java
@@ -19,6 +19,7 @@ package com.spotify.dns;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +53,7 @@ abstract class AbstractChangeNotifier<T> implements ChangeNotifier<T> {
       }
 
       if (fire) {
-        notifyListener(newChangeNotification(current(), Set.of()), true);
+        notifyListener(newChangeNotification(current(), Sets.newHashSet()), true);
       }
     } finally {
       lock.unlock();

--- a/src/main/java/com/spotify/dns/ChangeNotifiers.java
+++ b/src/main/java/com/spotify/dns/ChangeNotifiers.java
@@ -16,6 +16,8 @@
 
 package com.spotify.dns;
 
+import com.google.common.collect.Sets;
+
 import static com.spotify.dns.ChangeNotifierFactory.RunnableChangeNotifier;
 import static java.util.Objects.requireNonNull;
 
@@ -91,7 +93,7 @@ public final class ChangeNotifiers {
    * @return A notifier with a static set of records
    */
   public static <T> ChangeNotifier<T> staticRecords(T... records) {
-    return staticRecords(Set.of(records));
+    return staticRecords(Sets.newHashSet(records));
   }
 
   public static <T> ChangeNotifier<T> staticRecords(Set<T> records) {
@@ -118,8 +120,8 @@ public final class ChangeNotifiers {
 
   /**
    * @deprecated Use {@link #direct(java.util.function.Supplier)}
+   * deprecated since version 3.2.0
    */
-  @Deprecated(since = "3.2.0")
   public static <T> RunnableChangeNotifier<T> direct(com.google.common.base.Supplier<Set<T>> recordsSupplier) {
     return new DirectChangeNotifier<>(recordsSupplier);
   }

--- a/src/main/java/com/spotify/dns/DnsSrvWatchers.java
+++ b/src/main/java/com/spotify/dns/DnsSrvWatchers.java
@@ -76,8 +76,8 @@ public final class DnsSrvWatchers {
 
   /**
    * @deprecated Use {@link #newBuilder(DnsSrvResolver, java.util.function.Function)}
+   * deprecated since version 3.2.0
    */
-  @Deprecated(since = "3.2.0")
   public static <T> DnsSrvWatcherBuilder<T> newBuilder(
       DnsSrvResolver resolver,
       com.google.common.base.Function<LookupResult, T> resultTransformer) {

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,9 +1,0 @@
-module com.spotify.dns {
-
-  requires org.dnsjava;
-  requires com.google.common;
-  requires org.slf4j;
-
-  exports com.spotify.dns;
-  exports com.spotify.dns.statistics;
-}


### PR DESCRIPTION
Currently `dns-java` is compiled with jdk 9 which breaks https://github.com/spotify/folsom/pull/171#issuecomment-922865719

This reverts back some changes of jdk 8 -> 9 and removes the java module-info file.