### PR TITLE
Bug fix: Add default implementation of resolveAsync to ensure backwards compatible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,7 @@
                         <dependency>
                             <groupId>com.spotify</groupId>
                             <artifactId>${project.artifactId}</artifactId>
-                            <version>3.0.2</version>
+                            <version>3.3.0</version>
                         </dependency>
                     </oldVersion>
                     <newVersion>
@@ -322,6 +322,14 @@
                         </file>
                     </newVersion>
                     <parameter>
+                        <overrideCompatibilityChangeParameters>
+                            <overrideCompatibilityChangeParameter>
+                                <compatibilityChange>METHOD_ABSTRACT_NOW_DEFAULT</compatibilityChange>
+                                <binaryCompatible>true</binaryCompatible>
+                                <sourceCompatible>true</sourceCompatible>
+                                <semanticVersionLevel>PATCH</semanticVersionLevel>
+                            </overrideCompatibilityChangeParameter>
+                        </overrideCompatibilityChangeParameters>
                         <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
                         <onlyBinaryIncompatible>true</onlyBinaryIncompatible>
                     </parameter>

--- a/src/main/java/com/spotify/dns/DnsSrvResolver.java
+++ b/src/main/java/com/spotify/dns/DnsSrvResolver.java
@@ -45,5 +45,7 @@ public interface DnsSrvResolver {
    * @return a possibly empty list of matching records
    * @throws DnsException if there was an error doing the DNS lookup
    */
-  CompletionStage<List<LookupResult>> resolveAsync(String fqdn);
+  default CompletionStage<List<LookupResult>> resolveAsync(String fqdn) {
+    throw new java.lang.UnsupportedOperationException("Not implemented");
+  }
 }


### PR DESCRIPTION
This bug was introduced in https://github.com/spotify/dns-java/pull/47
which @erikjoh pointed out and I forgot to fix ^