### PR TITLE
Remove japicmp override and update old version number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,7 @@
                         <dependency>
                             <groupId>com.spotify</groupId>
                             <artifactId>${project.artifactId}</artifactId>
-                            <version>3.3.0</version>
+                            <version>3.3.2</version>
                         </dependency>
                     </oldVersion>
                     <newVersion>
@@ -322,14 +322,6 @@
                         </file>
                     </newVersion>
                     <parameter>
-                        <overrideCompatibilityChangeParameters>
-                            <overrideCompatibilityChangeParameter>
-                                <compatibilityChange>METHOD_ABSTRACT_NOW_DEFAULT</compatibilityChange>
-                                <binaryCompatible>true</binaryCompatible>
-                                <sourceCompatible>true</sourceCompatible>
-                                <semanticVersionLevel>PATCH</semanticVersionLevel>
-                            </overrideCompatibilityChangeParameter>
-                        </overrideCompatibilityChangeParameters>
                         <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
                         <onlyBinaryIncompatible>true</onlyBinaryIncompatible>
                     </parameter>


### PR DESCRIPTION
This override was introduced to fix bug in PR #53 